### PR TITLE
Potential fix for code scanning alert no. 313: Database query built from user-controlled sources

### DIFF
--- a/server-app/src/interfaces/http/controllers/password-reset-controller.js
+++ b/server-app/src/interfaces/http/controllers/password-reset-controller.js
@@ -19,7 +19,7 @@ export const sendPasswordResetEmail = async (req, res) => {
       });
     }
 
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
     if (!user) {
       return res.status(200).json({
         success: true,

--- a/server-app/src/interfaces/http/controllers/user-controller.js
+++ b/server-app/src/interfaces/http/controllers/user-controller.js
@@ -50,7 +50,13 @@ export const register = async (req, res) => {
       });
     }
 
-    const existingUsername = await User.findOne({ username });
+    if (typeof username !== "string") {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid username format",
+      });
+    }
+    const existingUsername = await User.findOne({ username: { $eq: username } });
     if (existingUsername) {
       return res.status(400).json({
         success: false,


### PR DESCRIPTION
Potential fix for [https://github.com/karanshukla/totalwarhammer-tournament-app/security/code-scanning/313](https://github.com/karanshukla/totalwarhammer-tournament-app/security/code-scanning/313)

To fix the issue, we need to ensure that the `email` value is treated as a literal value in the database query. This can be achieved by explicitly using MongoDB's `$eq` operator in the query. The `$eq` operator ensures that the input is interpreted as a literal value and not as a query object, thereby preventing NoSQL injection.

Steps to implement the fix:
1. Modify the query on line 22 to use the `$eq` operator for the `email` field.
2. Ensure no other changes are made to the functionality of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
