### PR TITLE
fix: add security headers to resolve ZAP scan vulnerabilities

### DIFF
--- a/client-app/index.html
+++ b/client-app/index.html
@@ -18,13 +18,7 @@
   <div id="preloader" class="preloader">
   </div>
   <script type="module" src="src/main.tsx"></script>
+  <script src="/preloader.js"></script>
 </body>
 
 </html>
-<script type="text/javascript">
-  window.onload = function () {
-    setTimeout(function () {
-      document.getElementById("body").style.display = "";
-    }, 50);
-  }
-</script>

--- a/client-app/public/preloader.js
+++ b/client-app/public/preloader.js
@@ -1,0 +1,5 @@
+window.onload = function () {
+  setTimeout(function () {
+    document.getElementById("body").style.display = "";
+  }, 50);
+};

--- a/docker/client/Caddyfile
+++ b/docker/client/Caddyfile
@@ -1,4 +1,15 @@
 :80 {
+    header {
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Cross-Origin-Opener-Policy "same-origin"
+        Cross-Origin-Embedder-Policy "require-corp"
+        Cross-Origin-Resource-Policy "same-origin"
+        Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), display-capture=()"
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+        -Server
+    }
+
     # Backend API routes — handled exclusively, no fallthrough to file_server
     handle /user* {
         reverse_proxy {$SERVER_URL:server:3000} {


### PR DESCRIPTION
Adds HTTP security headers to the Caddy frontend server to resolve all actionable ZAP scan alerts from issue #47.

Changes:
- `docker/client/Caddyfile`: Added Content-Security-Policy, X-Frame-Options, Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy, Permissions-Policy, and X-Content-Type-Options headers
- `client-app/public/preloader.js`: Extracted inline script from index.html to allow strict script-src 'self' CSP
- `client-app/index.html`: Replaced inline script tag with external script reference

Closes #47

Generated with [Claude Code](https://claude.ai/code)