### PR TITLE
Hide Create Account button for authenticated and guest users

### DIFF
--- a/client-app/src/features/home/components/HeroSection.tsx
+++ b/client-app/src/features/home/components/HeroSection.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  VStack,
   HStack,
   Button,
   Text,
@@ -9,52 +8,64 @@ import {
   Badge,
 } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
+import { useUserStore } from "@/shared/stores/userStore";
 
-const HeroSection: React.FC = () => (
-  <Box textAlign="center" py={8}>
-    <Badge
-      colorPalette="red"
-      mb={4}
-      px={3}
-      py={1}
-      fontSize="xs"
-      textTransform="uppercase"
-      letterSpacing="wider"
-    >
-      Total War: Warhammer
-    </Badge>
-    <Heading as="h1" size="4xl" fontWeight="bold" lineHeight="tight" mb={4}>
-      TW Tournament App
-    </Heading>
-    <Text
-      fontSize="lg"
-      color="fg.muted"
-      maxW="2xl"
-      mx="auto"
-      lineHeight="relaxed"
-      mb={8}
-    >
-      Create custom brackets, participate in Total War Warhammer tournaments
-      within the multiplayer community, and view statistics for recorded
-      matchups.
-    </Text>
-    <HStack gap={3} justify="center">
-      <Button colorPalette="blue" size="lg" asChild>
-        <Link to="/tournaments">View Ongoing Tournaments</Link>
-      </Button>
-      <Button
-        variant="outline"
-        size="lg"
-        onClick={() =>
-          document.dispatchEvent(
-            new CustomEvent("auth-event", { detail: { type: "open-drawer" } }),
-          )
-        }
+const HeroSection: React.FC = () => {
+  const userStore = useUserStore();
+  const isUserLoggedIn = Boolean(userStore.user.isAuthenticated);
+  const isUserGuest = Boolean(userStore.user.isGuest);
+  const showCreateAccount = !isUserLoggedIn && !isUserGuest;
+
+  return (
+    <Box textAlign="center" py={8}>
+      <Badge
+        colorPalette="red"
+        mb={4}
+        px={3}
+        py={1}
+        fontSize="xs"
+        textTransform="uppercase"
+        letterSpacing="wider"
       >
-        Create Account
-      </Button>
-    </HStack>
-  </Box>
-);
+        Total War: Warhammer
+      </Badge>
+      <Heading as="h1" size="4xl" fontWeight="bold" lineHeight="tight" mb={4}>
+        TW Tournament App
+      </Heading>
+      <Text
+        fontSize="lg"
+        color="fg.muted"
+        maxW="2xl"
+        mx="auto"
+        lineHeight="relaxed"
+        mb={8}
+      >
+        Create custom brackets, participate in Total War Warhammer tournaments
+        within the multiplayer community, and view statistics for recorded
+        matchups.
+      </Text>
+      <HStack gap={3} justify="center">
+        <Button colorPalette="blue" size="lg" asChild>
+          <Link to="/tournaments">View Ongoing Tournaments</Link>
+        </Button>
+        {showCreateAccount && (
+          <Button
+            variant="outline"
+            size="lg"
+            onClick={() =>
+              document.dispatchEvent(
+                new CustomEvent("auth-event", {
+                  detail: { type: "open-drawer" },
+                }),
+              )
+            }
+          >
+            Create Account
+          </Button>
+        )}
+      </HStack>
+    </Box>
+  );
+};
 
 export default HeroSection;

--- a/client-app/src/tests/features/home/HeroSection.test.tsx
+++ b/client-app/src/tests/features/home/HeroSection.test.tsx
@@ -1,10 +1,16 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import React from "react";
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { MemoryRouter } from "react-router-dom";
 import HeroSection from "@/features/home/components/HeroSection";
+
+const mockUseUserStore = vi.fn();
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: () => mockUseUserStore(),
+}));
 
 function renderHero() {
   return render(
@@ -17,6 +23,12 @@ function renderHero() {
 }
 
 describe("HeroSection", () => {
+  beforeEach(() => {
+    mockUseUserStore.mockReturnValue({
+      user: { isAuthenticated: false, isGuest: false },
+    });
+  });
+
   it("renders the app title", () => {
     renderHero();
     expect(
@@ -45,11 +57,31 @@ describe("HeroSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the Create Account button", () => {
+  it("renders the Create Account button for unauthenticated non-guest users", () => {
     renderHero();
     expect(
       screen.getByRole("button", { name: /Create Account/i }),
     ).toBeInTheDocument();
+  });
+
+  it("does not render the Create Account button for authenticated users", () => {
+    mockUseUserStore.mockReturnValue({
+      user: { isAuthenticated: true, isGuest: false },
+    });
+    renderHero();
+    expect(
+      screen.queryByRole("button", { name: /Create Account/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the Create Account button for guest users", () => {
+    mockUseUserStore.mockReturnValue({
+      user: { isAuthenticated: false, isGuest: true },
+    });
+    renderHero();
+    expect(
+      screen.queryByRole("button", { name: /Create Account/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("View Ongoing Tournaments link points to /tournaments", () => {


### PR DESCRIPTION
Hides the "Create Account" button in the home page hero section for users who are already authenticated or browsing as a guest, since the button is only relevant to new unauthenticated visitors.

Closes #90

Generated with [Claude Code](https://claude.ai/code)