### PR TITLE
Fix multi-device auth bugs and add session isolation tests

### DIFF
--- a/server-app/src/interfaces/http/controllers/user-controller.js
+++ b/server-app/src/interfaces/http/controllers/user-controller.js
@@ -184,7 +184,7 @@ export const updateUsername = async (req, res) => {
 
     const updatedUser = await User.findByIdAndUpdate(
       userId,
-      { $set: { username: { $eq: username } } },
+      { $set: { username } },
       { new: true },
     );
 
@@ -253,7 +253,7 @@ export const deleteAccount = async (req, res) => {
       });
     });
 
-    res.clearCookie("connect.sid");
+    res.clearCookie("sid");
     return res
       .status(200)
       .json({ success: true, message: "Account deleted successfully" });

--- a/server-app/src/tests/multi-device-auth.test.js
+++ b/server-app/src/tests/multi-device-auth.test.js
@@ -1,0 +1,239 @@
+import assert from "node:assert";
+import { describe, it, beforeEach, mock } from "node:test";
+
+import AuthStateService from "../infrastructure/services/auth-state-service.js";
+
+const CHROME_WINDOWS_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const FIREFOX_MAC_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.1; rv:120.0) Gecko/20100101 Firefox/120.0";
+const SAFARI_IOS_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+function makeDevice(userAgent) {
+  return {
+    session: { cookie: {} },
+    get: (header) => (header === "user-agent" ? userAgent : null),
+  };
+}
+
+const USER = {
+  _id: "user1",
+  email: "test@example.com",
+  username: "testuser",
+  role: "user",
+};
+
+describe("multi-device auth", () => {
+  let service;
+
+  beforeEach(() => {
+    service = new AuthStateService();
+  });
+
+  describe("concurrent sessions for the same user", () => {
+    it("two devices can be authenticated simultaneously", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      assert.strictEqual(deviceA.session.isAuthenticated, true);
+      assert.strictEqual(deviceB.session.isAuthenticated, true);
+    });
+
+    it("sessions are independent objects", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      assert.notStrictEqual(deviceA.session, deviceB.session);
+    });
+
+    it("each device gets its own UA fingerprint", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      assert.deepStrictEqual(deviceA.session.fingerprint, {
+        browser: "Chrome",
+        os: "Windows",
+      });
+      assert.deepStrictEqual(deviceB.session.fingerprint, {
+        browser: "Firefox",
+        os: "macOS",
+      });
+    });
+
+    it("each device remains authenticated independently", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      assert.strictEqual(service.isAuthenticated(deviceA), true);
+      assert.strictEqual(service.isAuthenticated(deviceB), true);
+    });
+
+    it("mobile device session is independent of desktop sessions", async () => {
+      const desktop = makeDevice(CHROME_WINDOWS_UA);
+      const mobile = makeDevice(SAFARI_IOS_UA);
+
+      await service.createUserAuthState(desktop, USER);
+      await service.createUserAuthState(mobile, USER);
+
+      assert.strictEqual(service.isAuthenticated(desktop), true);
+      assert.strictEqual(service.isAuthenticated(mobile), true);
+    });
+
+    it("three concurrent sessions all remain valid", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+      const deviceC = makeDevice(SAFARI_IOS_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+      await service.createUserAuthState(deviceC, USER);
+
+      assert.strictEqual(service.isAuthenticated(deviceA), true);
+      assert.strictEqual(service.isAuthenticated(deviceB), true);
+      assert.strictEqual(service.isAuthenticated(deviceC), true);
+    });
+  });
+
+  describe("per-device logout isolation", () => {
+    it("logging out device A does not affect device B", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      const destroyMock = mock.fn((cb) => {
+        deviceA.session.isAuthenticated = false;
+        cb();
+      });
+      deviceA.session.destroy = destroyMock;
+      service.clearAuthState(deviceA, () => {});
+
+      assert.strictEqual(service.isAuthenticated(deviceB), true);
+    });
+
+    it("device B retains user data after device A session is destroyed", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      const savedSessionB = deviceB.session;
+
+      deviceA.session.destroy = mock.fn((cb) => {
+        deviceA.session = null;
+        cb();
+      });
+      service.clearAuthState(deviceA, () => {});
+
+      assert.strictEqual(savedSessionB.user.id, "user1");
+      assert.strictEqual(savedSessionB.isAuthenticated, true);
+    });
+
+    it("logging out all devices clears each session independently", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      const callbackA = mock.fn();
+      const callbackB = mock.fn();
+
+      deviceA.session.destroy = mock.fn((cb) => cb());
+      deviceB.session.destroy = mock.fn((cb) => cb());
+
+      service.clearAuthState(deviceA, callbackA);
+      service.clearAuthState(deviceB, callbackB);
+
+      assert.strictEqual(callbackA.mock.calls.length, 1);
+      assert.strictEqual(callbackB.mock.calls.length, 1);
+    });
+  });
+
+  describe("cross-device fingerprint validation", () => {
+    it("device A request is rejected if its UA changes to a different browser", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      await service.createUserAuthState(deviceA, USER);
+
+      deviceA.get = (h) => (h === "user-agent" ? FIREFOX_MAC_UA : null);
+
+      assert.strictEqual(service.isAuthenticated(deviceA), false);
+    });
+
+    it("device B with different browser is valid regardless of device A fingerprint", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      assert.strictEqual(service.isAuthenticated(deviceA), true);
+      assert.strictEqual(service.isAuthenticated(deviceB), true);
+    });
+
+    it("fingerprint mismatch on device A does not invalidate device B", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, USER);
+      await service.createUserAuthState(deviceB, USER);
+
+      // Device A's UA changes mid-session (different browser family)
+      deviceA.get = (h) => (h === "user-agent" ? SAFARI_IOS_UA : null);
+
+      assert.strictEqual(service.isAuthenticated(deviceA), false);
+      assert.strictEqual(service.isAuthenticated(deviceB), true);
+    });
+  });
+
+  describe("per-session remember-me", () => {
+    it("device A can use remember-me while device B uses default timeout", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, { ...USER, rememberMe: true });
+      await service.createUserAuthState(deviceB, { ...USER, rememberMe: false });
+
+      assert.strictEqual(
+        deviceA.session.cookie.maxAge,
+        service.REMEMBER_ME_TIMEOUT,
+      );
+      assert.strictEqual(
+        deviceB.session.cookie.maxAge,
+        service.DEFAULT_AUTH_STATE_TIMEOUT,
+      );
+    });
+
+    it("remember-me on device A does not change device B cookie maxAge", async () => {
+      const deviceA = makeDevice(CHROME_WINDOWS_UA);
+      const deviceB = makeDevice(FIREFOX_MAC_UA);
+
+      await service.createUserAuthState(deviceA, { ...USER, rememberMe: true });
+      await service.createUserAuthState(deviceB, USER);
+
+      assert.strictEqual(
+        deviceA.session.cookie.maxAge,
+        service.REMEMBER_ME_TIMEOUT,
+      );
+      assert.strictEqual(
+        deviceB.session.cookie.maxAge,
+        service.DEFAULT_AUTH_STATE_TIMEOUT,
+      );
+    });
+  });
+});

--- a/server-app/src/tests/user-controller.test.js
+++ b/server-app/src/tests/user-controller.test.js
@@ -159,6 +159,23 @@ describe("user-controller", () => {
         "new",
       );
     });
+
+    it("should pass a plain string value to $set, not a query operator", async () => {
+      mockUserFindOne.mock.mockImplementation(() => null);
+      let capturedUpdate;
+      mockUserFindByIdAndUpdate.mock.mockImplementation(async (_id, update) => {
+        capturedUpdate = update;
+        return { id: "u1", username: "newname", email: "e@t.com" };
+      });
+      const req = mockReq({
+        body: { username: "newname" },
+        session: { user: {}, save: mock.fn((cb) => cb()) },
+      });
+      const res = mockRes();
+      await updateUsername(req, res);
+      assert.strictEqual(typeof capturedUpdate.$set.username, "string");
+      assert.strictEqual(capturedUpdate.$set.username, "newname");
+    });
   });
 
   describe("updatePassword", () => {
@@ -233,6 +250,18 @@ describe("user-controller", () => {
       await deleteAccount(req, res);
       assert.strictEqual(res.status.mock.calls[0].arguments[0], 200);
       assert.strictEqual(res.json.mock.calls[0].arguments[0].success, true);
+    });
+
+    it("should clear the sid cookie (not connect.sid)", async () => {
+      mockUserFindByIdAndUpdate.mock.mockImplementation(async () => ({
+        id: "u1",
+      }));
+      const req = mockReq({
+        session: { destroy: mock.fn((cb) => cb()) },
+      });
+      const res = mockRes();
+      await deleteAccount(req, res);
+      assert.strictEqual(res.clearCookie.mock.calls[0].arguments[0], "sid");
     });
   });
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `updateUsername` was passing `{ $set: { username: { $eq: username } } }` to MongoDB — `$eq` is a query operator and is not valid as an update value; this would throw a `MongoServerError` in production and never persist the new username
- **Bug fix**: `deleteAccount` was calling `res.clearCookie("connect.sid")` but the session cookie is named `"sid"` — the browser would keep a stale cookie pointing to a destroyed session after account deletion
- **Tests**: Added `multi-device-auth.test.js` (14 tests) covering the multi-device session behaviour and added regression tests for both bugs above

## Multi-device session behaviour

The system already supports multiple sessions per user correctly: each device gets its own independent session ID, login on device B does not invalidate device A, and logout only destroys the calling device's session. The new test file documents and locks in this behaviour.

**One known gap not fixed here**: changing a password does not invalidate peer sessions on other devices. Those sessions remain valid until they naturally expire (up to 30 days with remember-me). Addressing this properly requires either a per-user session index in the store or a `passwordChangedAt` timestamp check during `deserializeUser`.

## Test plan

- [ ] Run `node --experimental-vm-modules --experimental-test-module-mocks --test src/tests/user-controller.test.js` — 16 pass
- [ ] Run `node --experimental-vm-modules --experimental-test-module-mocks --test src/tests/multi-device-auth.test.js` — 14 pass
- [ ] Run `node --experimental-vm-modules --experimental-test-module-mocks --test src/tests/authentication-controller.test.js` — all pass

https://claude.ai/code/session_01EueKMt9jjn8zR1iYkfuKcg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EueKMt9jjn8zR1iYkfuKcg)_