### PR TITLE
fix: navigate participants back to their tournament view from spectator mode

### DIFF
--- a/client-app/src/features/tournaments/components/TournamentViewPage.tsx
+++ b/client-app/src/features/tournaments/components/TournamentViewPage.tsx
@@ -260,7 +260,16 @@ const TournamentViewPage: React.FC = () => {
   return (
     <Container maxW="container.xl" py={8}>
       {/* Back */}
-      <Button variant="ghost" size="sm" mb={6} onClick={() => navigate(-1)}>
+      <Button
+        variant="ghost"
+        size="sm"
+        mb={6}
+        onClick={() =>
+          isParticipant || isOwner
+            ? navigate(`/matches#${tournament._id}`)
+            : navigate(-1)
+        }
+      >
         <LuChevronLeft /> Back
       </Button>
 


### PR DESCRIPTION
Fixes #94

The Back button in TournamentViewPage used `navigate(-1)` which relies on browser history. For participants and owners, this could land on `/matches` without the hash, showing the tournament list instead of the TournamentDetail view.

Now the back button explicitly navigates to `/matches#{id}` for participants and owners, reliably restoring their interactive view. Pure spectators continue to use `navigate(-1)`.

Generated with [Claude Code](https://claude.ai/code)