### PR TITLE
fix: patch express-mongo-sanitize for Express 5 req.query incompatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1960,9 +1960,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1980,9 +1977,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2000,9 +1994,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2020,9 +2011,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2040,9 +2028,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2060,9 +2045,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2234,9 +2216,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2251,9 +2230,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2268,9 +2244,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2285,9 +2258,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2302,9 +2272,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2319,9 +2286,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,9 +2300,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,9 +2314,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2370,9 +2328,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2387,9 +2342,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2404,9 +2356,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2421,9 +2370,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,9 +2384,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8773,9 +8716,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8797,9 +8737,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8821,9 +8758,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8845,9 +8779,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10696,7 +10627,7 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/server-app/app.js
+++ b/server-app/app.js
@@ -42,16 +42,23 @@ connectToDatabase();
 
 // Security
 app.use(helmet({}));
-app.use(mongoSanitize());
-app.use((req, _res, next) => {
-  if (req.body) {
-    for (const [key, value] of Object.entries(req.body)) {
-      if (typeof value === "string") {
-        req.body[key] = xssFilter.process(value);
-      }
-    }
-  }
 
+// Express 5 made req.query a read-only getter that returns a fresh object on
+// every access, so express-mongo-sanitize's strategy of reassigning req.query
+// throws a TypeError. Instead we shadow the getter with a sanitized own
+// property so all subsequent middleware can safely read and write req.query.
+app.use((req, _res, next) => {
+  const sanitizedQuery = mongoSanitize.sanitize({ ...req.query });
+  Object.defineProperty(req, "query", {
+    value: sanitizedQuery,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  next();
+});
+
+app.use((req, _res, next) => {
   if (req.query) {
     for (const [key, value] of Object.entries(req.query)) {
       if (typeof value === "string") {
@@ -115,6 +122,22 @@ app.use(csrfPrerequisiteCheck);
 // JSON and URL encoded middleware — limit body size to prevent payload flooding
 app.use(express.json({ limit: "50kb" }));
 app.use(express.urlencoded({ extended: true, limit: "50kb" }));
+
+// Sanitize parsed body and apply XSS filter to body strings.
+// Both must run after body parsing; previously mongoSanitize ran before
+// express.json() so req.body was always undefined there.
+app.use((req, _res, next) => {
+  if (req.body) {
+    req.body = mongoSanitize.sanitize(req.body);
+    for (const [key, value] of Object.entries(req.body)) {
+      if (typeof value === "string") {
+        req.body[key] = xssFilter.process(value);
+      }
+    }
+  }
+  next();
+});
+
 app.use(express.static("public"));
 
 // Global rate limiter — wide safety net


### PR DESCRIPTION
$(cat <<'EOF'
## Root cause

The `cve fixes` commit bumped `express` from `^4.x` to `^5.0.0`. Express 5 changed `req.query` from a writable property to a **read-only getter** that re-parses the query string fresh on every access.

`express-mongo-sanitize` v2.2.0 (the latest available version) still uses the Express 4 strategy of replacing the entire property:

```js
req[key] = target;  // key = 'query' → throws in Express 5
```

This threw a `TypeError` on **every single incoming request**, causing all endpoints to return 500.

```
TypeError: Cannot set property query of #<IncomingMessage> which has only a getter
    at node_modules/express-mongo-sanitize/index.js:113:18
```

## Fix

Replaced `app.use(mongoSanitize())` with a custom middleware that:

1. **Shadows the read-only prototype getter** with a sanitized writable own property via `Object.defineProperty`. All subsequent middleware (XSS filter, `hpp`) can then safely read and mutate `req.query` normally.

2. **Moved body sanitization to after the body parser.** Previously, `mongoSanitize()` ran before `express.json()`, meaning `req.body` was always `undefined` there — body was never actually being sanitized. The new body middleware runs after body parsing and correctly sanitizes + XSS-filters body strings.

## Test plan

- [ ] `POST /guest/` returns 200 with guest user data (was returning 500)
- [ ] `GET /auth/csrf-token` returns CSRF token (was returning 500)
- [ ] Login, registration, and all other endpoints respond correctly
- [ ] Query params containing MongoDB operators (e.g. `?$where=...`) are stripped
- [ ] Request body containing MongoDB operators is stripped

https://claude.ai/code/session_01NjqutkwJK6opPSvyQUrvAx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjqutkwJK6opPSvyQUrvAx)_