### PR TITLE
ci: switch OWASP ZAP to API scan with OpenAPI spec

### DIFF
--- a/.github/openapi.yml
+++ b/.github/openapi.yml
@@ -1,0 +1,836 @@
+openapi: "3.0.3"
+info:
+  title: TW Tournament App API
+  version: "1.0.0"
+servers:
+  - url: http://localhost/api
+
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: connect.sid
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+
+paths:
+  # ── Auth ──────────────────────────────────────────────────────────────────
+  /auth/csrf-token:
+    get:
+      summary: Get CSRF token
+      operationId: getCsrfToken
+      responses:
+        "200":
+          description: CSRF token issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  csrfToken:
+                    type: string
+                  sessionId:
+                    type: string
+
+  /auth/login:
+    post:
+      summary: Login with email/username and password
+      operationId: authLogin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [identifier, password]
+              properties:
+                identifier:
+                  type: string
+                  example: user@example.com
+                password:
+                  type: string
+                  example: password123
+      responses:
+        "200":
+          description: Authenticated
+        "400":
+          description: Validation error
+        "401":
+          description: Invalid credentials
+
+  /auth/logout:
+    post:
+      summary: Logout (POST)
+      operationId: authLogoutPost
+      responses:
+        "200":
+          description: Logged out
+    delete:
+      summary: Logout (DELETE)
+      operationId: authLogoutDelete
+      responses:
+        "200":
+          description: Logged out
+
+  /auth/token:
+    post:
+      summary: Exchange PKCE code for session
+      operationId: authToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [code, codeVerifier]
+              properties:
+                code:
+                  type: string
+                codeVerifier:
+                  type: string
+      responses:
+        "200":
+          description: Session established
+        "400":
+          description: Invalid or expired code
+        "401":
+          description: Code verifier mismatch
+
+  # ── User ──────────────────────────────────────────────────────────────────
+  /user/register:
+    post:
+      summary: Register a new user account
+      operationId: userRegister
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username, email, password]
+              properties:
+                username:
+                  type: string
+                  example: player1
+                email:
+                  type: string
+                  example: player1@example.com
+                password:
+                  type: string
+                  example: SecurePass1!
+      responses:
+        "201":
+          description: Registered
+        "400":
+          description: Validation error
+        "409":
+          description: Username or email already taken
+
+  /user/exists:
+    get:
+      summary: Check if a username or email is taken
+      operationId: userExists
+      parameters:
+        - name: username
+          in: query
+          schema:
+            type: string
+        - name: email
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Existence check result
+        "400":
+          description: Missing query param
+
+  /user/login:
+    post:
+      summary: Login (user-scoped alias)
+      operationId: userLogin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [identifier, password]
+              properties:
+                identifier:
+                  type: string
+                password:
+                  type: string
+      responses:
+        "200":
+          description: Authenticated
+        "401":
+          description: Invalid credentials
+
+  /user/logout:
+    post:
+      summary: Logout (user-scoped)
+      operationId: userLogout
+      security:
+        - sessionCookie: []
+      responses:
+        "200":
+          description: Logged out
+        "403":
+          description: CSRF validation failed
+
+  /user/update-username:
+    post:
+      summary: Update username (authenticated)
+      operationId: updateUsername
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username]
+              properties:
+                username:
+                  type: string
+      responses:
+        "200":
+          description: Username updated
+        "401":
+          description: Not authenticated
+        "409":
+          description: Username taken
+
+  /user/update-password:
+    post:
+      summary: Update password (authenticated)
+      operationId: updatePassword
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [currentPassword, newPassword]
+              properties:
+                currentPassword:
+                  type: string
+                newPassword:
+                  type: string
+      responses:
+        "200":
+          description: Password updated
+        "401":
+          description: Not authenticated or wrong current password
+
+  /user/account:
+    delete:
+      summary: Delete own account (authenticated)
+      operationId: deleteAccount
+      security:
+        - sessionCookie: []
+      responses:
+        "200":
+          description: Account deleted
+        "401":
+          description: Not authenticated
+        "403":
+          description: CSRF validation failed
+
+  /user/stats:
+    get:
+      summary: Get stats for authenticated user
+      operationId: getUserStats
+      security:
+        - sessionCookie: []
+      responses:
+        "200":
+          description: User stats
+        "401":
+          description: Not authenticated
+
+  # ── Guest ─────────────────────────────────────────────────────────────────
+  /guest:
+    post:
+      summary: Create a guest session
+      operationId: createGuest
+      responses:
+        "201":
+          description: Guest created
+        "200":
+          description: Guest session already exists
+
+  /guest/username:
+    post:
+      summary: Set guest username
+      operationId: updateGuestUsername
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username]
+              properties:
+                username:
+                  type: string
+      responses:
+        "200":
+          description: Username set
+        "401":
+          description: Not a guest session
+
+  # ── Password Reset ─────────────────────────────────────────────────────────
+  /password-reset/request:
+    post:
+      summary: Request a password reset email
+      operationId: requestPasswordReset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email:
+                  type: string
+                  example: player1@example.com
+      responses:
+        "200":
+          description: Reset email sent (or silently ignored if not found)
+        "400":
+          description: Validation error
+
+  /password-reset/verify:
+    post:
+      summary: Verify a password reset token
+      operationId: verifyResetToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token]
+              properties:
+                token:
+                  type: string
+      responses:
+        "200":
+          description: Token valid
+        "400":
+          description: Invalid or expired token
+
+  /password-reset/reset:
+    post:
+      summary: Reset password using a valid token
+      operationId: resetPassword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token, newPassword]
+              properties:
+                token:
+                  type: string
+                newPassword:
+                  type: string
+      responses:
+        "200":
+          description: Password reset
+        "400":
+          description: Invalid or expired token
+
+  # ── Tournament ─────────────────────────────────────────────────────────────
+  /tournament:
+    get:
+      summary: List all public tournaments
+      operationId: getTournaments
+      responses:
+        "200":
+          description: List of tournaments
+    post:
+      summary: Create a tournament (authenticated)
+      operationId: createTournament
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, format]
+              properties:
+                name:
+                  type: string
+                format:
+                  type: string
+                  enum: [single_elimination, double_elimination, round_robin, swiss]
+                description:
+                  type: string
+                maxParticipants:
+                  type: integer
+      responses:
+        "201":
+          description: Tournament created
+        "401":
+          description: Not authenticated
+
+  /tournament/mine:
+    get:
+      summary: Get tournaments created by the authenticated user
+      operationId: getUserTournaments
+      security:
+        - sessionCookie: []
+      responses:
+        "200":
+          description: User's tournaments
+        "401":
+          description: Not authenticated
+
+  /tournament/code/{code}:
+    get:
+      summary: Get tournament by join code
+      operationId: getTournamentByCode
+      parameters:
+        - name: code
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Tournament data
+        "404":
+          description: Not found
+
+  /tournament/{id}:
+    get:
+      summary: Get tournament by ID
+      operationId: getTournamentById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Tournament data
+        "404":
+          description: Not found
+    delete:
+      summary: Delete tournament (authenticated, creator only)
+      operationId: deleteTournament
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Deleted
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not the creator
+        "404":
+          description: Not found
+
+  /tournament/{id}/participants:
+    post:
+      summary: Add participant (authenticated)
+      operationId: addParticipant
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: Participant added
+        "401":
+          description: Not authenticated
+
+  /tournament/{id}/participants/{participantId}:
+    patch:
+      summary: Update participant (authenticated)
+      operationId: updateParticipant
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: participantId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: Participant updated
+        "401":
+          description: Not authenticated
+    delete:
+      summary: Remove participant (authenticated)
+      operationId: removeParticipant
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: participantId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Participant removed
+        "401":
+          description: Not authenticated
+
+  /tournament/{id}/join:
+    post:
+      summary: Join a tournament (authenticated)
+      operationId: joinTournament
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Joined
+        "401":
+          description: Not authenticated
+        "404":
+          description: Not found
+
+  /tournament/{id}/start:
+    post:
+      summary: Start a tournament (authenticated, creator only)
+      operationId: startTournament
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Started
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not the creator
+
+  /tournament/{id}/advance:
+    post:
+      summary: Advance tournament round (authenticated, creator only)
+      operationId: advanceRound
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Round advanced
+        "401":
+          description: Not authenticated
+
+  /tournament/{id}/description:
+    patch:
+      summary: Update tournament description (authenticated)
+      operationId: updateDescription
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [description]
+              properties:
+                description:
+                  type: string
+      responses:
+        "200":
+          description: Description updated
+        "401":
+          description: Not authenticated
+
+  # ── Match ─────────────────────────────────────────────────────────────────
+  /match/tournament/{tournamentId}:
+    get:
+      summary: Get all matches for a tournament
+      operationId: getMatchesByTournament
+      parameters:
+        - name: tournamentId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of matches
+        "404":
+          description: Tournament not found
+
+  /match/{id}:
+    get:
+      summary: Get a match by ID
+      operationId: getMatchById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Match data
+        "404":
+          description: Not found
+
+  /match:
+    post:
+      summary: Create a match (authenticated)
+      operationId: createMatch
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tournamentId, player1, player2]
+              properties:
+                tournamentId:
+                  type: string
+                player1:
+                  type: string
+                player2:
+                  type: string
+      responses:
+        "201":
+          description: Match created
+        "401":
+          description: Not authenticated
+
+  /match/{id}/report:
+    patch:
+      summary: Report match result (authenticated participant)
+      operationId: reportResult
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [winnerId]
+              properties:
+                winnerId:
+                  type: string
+      responses:
+        "200":
+          description: Result reported
+        "401":
+          description: Not authenticated
+
+  /match/{id}/result:
+    patch:
+      summary: Record match result (authenticated)
+      operationId: recordResult
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [winnerId]
+              properties:
+                winnerId:
+                  type: string
+      responses:
+        "200":
+          description: Result recorded
+        "401":
+          description: Not authenticated
+
+  /match/{id}/resolve:
+    patch:
+      summary: Resolve a disputed match (authenticated, creator)
+      operationId: resolveDispute
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [winnerId]
+              properties:
+                winnerId:
+                  type: string
+      responses:
+        "200":
+          description: Dispute resolved
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not the tournament creator
+
+  /match/{id}/override:
+    patch:
+      summary: Override match result (authenticated, creator)
+      operationId: overrideResult
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [winnerId]
+              properties:
+                winnerId:
+                  type: string
+      responses:
+        "200":
+          description: Result overridden
+        "401":
+          description: Not authenticated
+
+  /match/{id}/status:
+    patch:
+      summary: Update match status (authenticated)
+      operationId: updateMatchStatus
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [pending, in_progress, completed, disputed]
+      responses:
+        "200":
+          description: Status updated
+        "401":
+          description: Not authenticated
+
+  # ── Stats ──────────────────────────────────────────────────────────────────
+  /stats:
+    get:
+      summary: Get global app statistics
+      operationId: getStats
+      responses:
+        "200":
+          description: Global stats

--- a/.github/workflows/zapScan.yml
+++ b/.github/workflows/zapScan.yml
@@ -10,6 +10,8 @@ on:
       - "docker/server/Dockerfile"
       - "docker/client/Dockerfile"
       - "caddy/**"
+      - ".github/openapi.yml"
+      - ".github/workflows/zapScan.yml"
   pull_request:
     branches: ["main"]
     paths:
@@ -19,6 +21,8 @@ on:
       - "docker/server/Dockerfile"
       - "docker/client/Dockerfile"
       - "caddy/**"
+      - ".github/openapi.yml"
+      - ".github/workflows/zapScan.yml"
 
 permissions:
   contents: read
@@ -63,18 +67,23 @@ jobs:
             echo "Attempt $i/40 - HTTP $STATUS, waiting..."
             sleep 3
           done
-          # Also verify backend is reachable through Caddy
-          curl -sf http://localhost/auth/csrf-token && echo "Backend reachable" || echo "Backend not yet ready"
+          # Verify backend API is reachable through Caddy reverse proxy
+          API_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/api/auth/csrf-token)
+          echo "Backend API status: $API_STATUS"
+          if [ "$API_STATUS" != "200" ]; then
+            echo "WARNING: Backend API not returning 200 on /api/auth/csrf-token (got $API_STATUS)"
+          fi
 
-      - name: Run OWASP ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.14.0
+      - name: Run OWASP ZAP API Scan
+        uses: zaproxy/action-api-scan@v0.9.0
         with:
-          target: "http://localhost"
+          target: ".github/openapi.yml"
+          format: openapi
           rules_file_name: ".github/zap-rules.tsv"
           fail_action: false
           allow_issue_writing: true
-          artifact_name: zap-baseline-report
-          cmd_options: "-a"
+          artifact_name: zap-api-report
+          cmd_options: "-config replacer.full_list(0).description=auth -config replacer.full_list(0).enabled=true -config replacer.full_list(0).matchtype=REQ_HEADER -config replacer.full_list(0).matchstr=Host -config replacer.full_list(0).replacement=localhost"
 
       - name: Stop containers
         if: always()

--- a/.github/workflows/zapScan.yml
+++ b/.github/workflows/zapScan.yml
@@ -83,7 +83,6 @@ jobs:
           fail_action: false
           allow_issue_writing: true
           artifact_name: zap-api-report
-          cmd_options: "-config replacer.full_list(0).description=auth -config replacer.full_list(0).enabled=true -config replacer.full_list(0).matchtype=REQ_HEADER -config replacer.full_list(0).matchstr=Host -config replacer.full_list(0).replacement=localhost"
 
       - name: Stop containers
         if: always()


### PR DESCRIPTION
## Summary

The old baseline scan spidered `http://localhost` and only hit the React SPA — the Express backend behind Caddy's `/api` proxy was never actually probed.

- **Add `.github/openapi.yml`** — complete OpenAPI 3.0 spec covering all 30+ API endpoints (auth, user, guest, password-reset, tournament, match, stats) with correct auth requirements annotated
- **Switch to `action-api-scan`** — ZAP now probes every known endpoint with active fuzz/injection attacks (SQLi, XSS, auth bypass, etc.) rather than spidering HTML
- **Fix readiness check** — verifies backend is up via `/api/auth/csrf-token` (correct Caddy path) instead of the old `/auth/csrf-token` which wasn't proxied
- **Add path triggers** for `openapi.yml` and `zapScan.yml` so changes to the spec re-run the scan

## How it works

ZAP reads the OpenAPI spec (server URL: `http://localhost/api`), sends real HTTP requests to every endpoint through Caddy, and checks that authenticated routes return 401 unauthenticated, that mutation endpoints enforce CSRF, etc.

## Test plan
- [ ] Check ZAP artifact report in Actions to confirm requests are hitting `/api/*` routes (look for 401s on protected endpoints, not 404s)
- [ ] Confirm no 200s returned for bogus/malformed payloads on auth endpoints

https://claude.ai/code/session_0194eCiCF5Z9DZNuW8T9E8EP

---
_Generated by [Claude Code](https://claude.ai/code/session_0194eCiCF5Z9DZNuW8T9E8EP)_