### PR TITLE
Exclude 40k faction tournaments from statistics and leaderboards

### DIFF
--- a/server-app/src/infrastructure/services/stats-service.js
+++ b/server-app/src/infrastructure/services/stats-service.js
@@ -36,6 +36,20 @@ export async function invalidateStatsCache() {
   }
 }
 
+// Reusable pipeline stages to join a match's tournament and exclude 40k tournaments
+const matchTo40kFreeStages = [
+  {
+    $lookup: {
+      from: "tournaments",
+      localField: "tournament",
+      foreignField: "_id",
+      as: "_tournament",
+    },
+  },
+  { $unwind: { path: "$_tournament", preserveNullAndEmptyArrays: true } },
+  { $match: { "_tournament.enable40kFactions": { $ne: true } } },
+];
+
 async function computeGlobalStats() {
   const [
     tournamentStats,
@@ -46,10 +60,15 @@ async function computeGlobalStats() {
     recentTournaments,
     recentWinners,
   ] = await Promise.all([
-    Tournament.aggregate([{ $group: { _id: "$status", count: { $sum: 1 } } }]),
+    // Exclude 40k tournaments from counts
+    Tournament.aggregate([
+      { $match: { enable40kFactions: { $ne: true } } },
+      { $group: { _id: "$status", count: { $sum: 1 } } },
+    ]),
 
     Match.aggregate([
       { $match: { status: "completed", winnerId: { $ne: null } } },
+      ...matchTo40kFreeStages,
       {
         $project: {
           winnerName: {
@@ -82,6 +101,7 @@ async function computeGlobalStats() {
 
     Match.aggregate([
       { $match: { status: "completed", winnerId: { $ne: null } } },
+      ...matchTo40kFreeStages,
       {
         $project: {
           winnerFaction: {
@@ -112,7 +132,9 @@ async function computeGlobalStats() {
       { $project: { faction: "$_id", wins: 1, _id: 0 } },
     ]),
 
+    // Exclude 40k tournaments from creator counts
     Tournament.aggregate([
+      { $match: { enable40kFactions: { $ne: true } } },
       {
         $group: {
           _id: "$createdBy",
@@ -143,9 +165,14 @@ async function computeGlobalStats() {
       },
     ]),
 
-    Match.aggregate([{ $group: { _id: "$status", count: { $sum: 1 } } }]),
+    // Exclude matches from 40k tournaments
+    Match.aggregate([
+      ...matchTo40kFreeStages,
+      { $group: { _id: "$status", count: { $sum: 1 } } },
+    ]),
 
-    Tournament.find({ status: "completed" })
+    // Exclude 40k tournaments from recent list
+    Tournament.find({ status: "completed", enable40kFactions: { $ne: true } })
       .sort({ createdAt: -1 })
       .limit(5)
       .select("name tournamentType participants playerCount createdAt")
@@ -183,7 +210,13 @@ async function computeGlobalStats() {
       {
         $unwind: { path: "$tournamentDoc", preserveNullAndEmptyArrays: true },
       },
-      { $match: { "tournamentDoc.status": "completed" } },
+      // Exclude 40k tournaments and only show completed non-40k ones
+      {
+        $match: {
+          "tournamentDoc.status": "completed",
+          "tournamentDoc.enable40kFactions": { $ne: true },
+        },
+      },
       {
         $project: {
           tournamentName: { $ifNull: ["$tournamentDoc.name", "Unknown"] },

--- a/server-app/src/interfaces/http/controllers/user-controller.js
+++ b/server-app/src/interfaces/http/controllers/user-controller.js
@@ -280,15 +280,33 @@ export const getUserStats = async (req, res) => {
 
     const username = user.username;
 
+    const non40kTournamentIds = await Tournament.find({
+      enable40kFactions: { $ne: true },
+    })
+      .select("_id")
+      .lean()
+      .then((docs) => docs.map((d) => d._id));
+
     const [tournamentsCreatedCount, matchesAsP1, matchesAsP2] =
       await Promise.all([
-        Tournament.countDocuments({ createdBy: userId }),
+        Tournament.countDocuments({
+          createdBy: userId,
+          enable40kFactions: { $ne: true },
+        }),
 
-        Match.find({ "player1.name": username, status: "completed" })
+        Match.find({
+          "player1.name": username,
+          status: "completed",
+          tournament: { $in: non40kTournamentIds },
+        })
           .select("player1 player2 winnerId tournament")
           .lean(),
 
-        Match.find({ "player2.name": username, status: "completed" })
+        Match.find({
+          "player2.name": username,
+          status: "completed",
+          tournament: { $in: non40kTournamentIds },
+        })
           .select("player1 player2 winnerId tournament")
           .lean(),
       ]);


### PR DESCRIPTION
## Summary

- 40k tournaments (`enable40kFactions: true`) are now excluded from all global stats: tournament/match counts, top players, top factions, top creators, recent tournaments, and recent winners
- User-level stats (tournaments created, matches played, wins/losses, faction breakdown) also exclude 40k tournament data
- Achieved via `enable40kFactions: { $ne: true }` filters on Tournament queries and a reusable `$lookup` pipeline to filter Match aggregations by their parent tournament

## Test plan

- [ ] Create a WH3 tournament, complete a match — verify it appears in stats/leaderboards
- [ ] Create a 40k tournament, complete a match — verify it does NOT appear in stats, top players, recent winners, or tournament counts
- [ ] Check user stats page for a player who played in both types — only WH3 matches should count

https://claude.ai/code/session_01AbYF67TaB3tJh17nye6Z3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbYF67TaB3tJh17nye6Z3i)_