### PR TITLE
test: unit test coverage batch 2 (5 files)

### DIFF
--- a/client-app/src/tests/features/bracket/TournamentBracketExtended.test.tsx
+++ b/client-app/src/tests/features/bracket/TournamentBracketExtended.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { DndContext } from "@dnd-kit/core";
+import { TournamentBracket } from "@/features/tournaments/components/bracket/TournamentBracket";
+import { useTournamentStore } from "@/shared/stores/tournamentStore";
+
+function renderBracket() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <DndContext>
+        <TournamentBracket />
+      </DndContext>
+    </ChakraProvider>,
+  );
+}
+
+describe("TournamentBracket - participant slot removal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useTournamentStore.getState().resetParticipantsAndBracket();
+  });
+
+  it("shows 'Remove participant' button when a participant is assigned to a slot", () => {
+    // Default state has participants assigned to m1 (p1, p2), etc.
+    renderBracket();
+    // The "×" button with aria-label "Remove participant" should appear
+    const removeButtons = screen.getAllByRole("button", {
+      name: /remove participant/i,
+    });
+    expect(removeButtons.length).toBeGreaterThan(0);
+  });
+
+  it("removes participant from position 1 when Remove participant is clicked", async () => {
+    const store = useTournamentStore.getState();
+    const firstMatch = store.rounds[0].matches[0];
+    // Ensure participant1Id is set
+    expect(firstMatch.participant1Id).not.toBeNull();
+
+    renderBracket();
+
+    const removeButtons = screen.getAllByRole("button", {
+      name: /remove participant/i,
+    });
+    await userEvent.click(removeButtons[0]);
+
+    const updatedState = useTournamentStore.getState();
+    // One of the match slots should now be null
+    const allMatches = updatedState.rounds.flatMap((r) => r.matches);
+    const firstUpdatedMatch = allMatches.find((m) => m.id === firstMatch.id)!;
+    // Either participant1Id or participant2Id was cleared
+    expect(
+      firstUpdatedMatch.participant1Id === null ||
+        firstUpdatedMatch.participant2Id === null,
+    ).toBe(true);
+  });
+
+  it("calls updateMatchParticipant with null to clear position 1", async () => {
+    const store = useTournamentStore.getState();
+    const firstMatch = store.rounds[0].matches[0];
+    const originalP1Id = firstMatch.participant1Id;
+
+    renderBracket();
+
+    // The first "Remove participant" button corresponds to position 1 of match 1
+    const removeButtons = screen.getAllByRole("button", {
+      name: /remove participant/i,
+    });
+    await userEvent.click(removeButtons[0]);
+
+    const updatedMatch = useTournamentStore
+      .getState()
+      .rounds[0].matches.find((m) => m.id === firstMatch.id)!;
+
+    // The participant should have been removed (set to null)
+    expect(updatedMatch.participant1Id).toBeNull();
+    expect(originalP1Id).not.toBeNull(); // Confirm we started with a participant
+  });
+
+  it("calls updateMatchParticipant with null to clear position 2", async () => {
+    const store = useTournamentStore.getState();
+    const firstMatch = store.rounds[0].matches[0];
+    const originalP2Id = firstMatch.participant2Id;
+
+    renderBracket();
+
+    // The second "Remove participant" button corresponds to position 2 of match 1
+    const removeButtons = screen.getAllByRole("button", {
+      name: /remove participant/i,
+    });
+    if (removeButtons.length >= 2) {
+      await userEvent.click(removeButtons[1]);
+
+      const updatedMatch = useTournamentStore
+        .getState()
+        .rounds[0].matches.find((m) => m.id === firstMatch.id)!;
+
+      expect(updatedMatch.participant2Id).toBeNull();
+      expect(originalP2Id).not.toBeNull();
+    }
+  });
+
+  it("onRemoveParticipantFromSlot uses 'participant2Id' when position is 2", async () => {
+    // Set up a match where participant2Id is set
+    const store = useTournamentStore.getState();
+    const rounds = store.rounds;
+    const matchWithBothParticipants = rounds
+      .flatMap((r) => r.matches)
+      .find((m) => m.participant1Id && m.participant2Id);
+
+    if (matchWithBothParticipants) {
+      renderBracket();
+
+      const allRemoveButtons = screen.getAllByRole("button", {
+        name: /remove participant/i,
+      });
+
+      // Find a button that removes participant2 (every 2nd button for a match with both)
+      // Click the second remove button
+      if (allRemoveButtons.length >= 2) {
+        await userEvent.click(allRemoveButtons[1]);
+
+        const updatedState = useTournamentStore.getState();
+        const updatedMatch = updatedState.rounds
+          .flatMap((r) => r.matches)
+          .find((m) => m.id === matchWithBothParticipants.id);
+
+        // participant2Id should now be null
+        expect(updatedMatch?.participant2Id).toBeNull();
+      }
+    }
+  });
+});

--- a/client-app/src/tests/stores/tournamentStoreRoundSortKey.test.ts
+++ b/client-app/src/tests/stores/tournamentStoreRoundSortKey.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useTournamentStore } from "@/shared/stores/tournamentStore";
+import type { Round } from "@/features/tournaments/components/bracket/types";
+
+describe("tournamentStore – getRoundSortKey via sortRounds", () => {
+  beforeEach(() => {
+    useTournamentStore.getState().resetParticipantsAndBracket();
+  });
+
+  const makeRound = (id: string, title: string): Round => ({
+    id,
+    title,
+    matches: [],
+  });
+
+  it("sorts 'Bronze Final' (key 99) after regular rounds but before Finals (key 100)", () => {
+    useTournamentStore.setState({
+      rounds: [
+        makeRound("r-finals", "Finals"),
+        makeRound("r-bronze", "Bronze Final"),
+        makeRound("r-round1", "Round 1"),
+      ],
+    });
+
+    // Trigger addRound which calls sortRounds internally
+    useTournamentStore.getState().addRound();
+
+    const titles = useTournamentStore.getState().rounds.map((r) => r.title);
+    const bronzeIdx = titles.indexOf("Bronze Final");
+    const finalsIdx = titles.indexOf("Finals");
+    const round1Idx = titles.indexOf("Round 1");
+
+    // Round 1 (key 11) < Bronze Final (key 99) < Finals (key 100)
+    expect(round1Idx).toBeLessThan(bronzeIdx);
+    expect(bronzeIdx).toBeLessThan(finalsIdx);
+  });
+
+  it("sorts '3rd Place' (key 99) identically to 'Bronze Final'", () => {
+    useTournamentStore.setState({
+      rounds: [
+        makeRound("r-finals", "Finals"),
+        makeRound("r-3rd", "3rd Place"),
+        makeRound("r-semi", "Semi-Final"),
+      ],
+    });
+
+    useTournamentStore.getState().addRound();
+
+    const titles = useTournamentStore.getState().rounds.map((r) => r.title);
+    const thirdPlaceIdx = titles.indexOf("3rd Place");
+    const finalsIdx = titles.indexOf("Finals");
+    const semiIdx = titles.indexOf("Semi-Final");
+
+    // Semi-Final (90) < 3rd Place (99) < Finals (100)
+    expect(semiIdx).toBeLessThan(thirdPlaceIdx);
+    expect(thirdPlaceIdx).toBeLessThan(finalsIdx);
+  });
+
+  it("sorts unmatched title (key 50) between numbered rounds and special stages", () => {
+    useTournamentStore.setState({
+      rounds: [
+        makeRound("r-finals", "Finals"),
+        makeRound("r-custom", "Group Stage"), // unmatched → key 50
+        makeRound("r-round5", "Round 5"),    // key 15
+      ],
+    });
+
+    useTournamentStore.getState().addRound();
+
+    const titles = useTournamentStore.getState().rounds.map((r) => r.title);
+    const groupIdx = titles.indexOf("Group Stage");
+    const finalsIdx = titles.indexOf("Finals");
+    const round5Idx = titles.indexOf("Round 5");
+
+    // Round 5 (key 15) < Group Stage (key 50) < Finals (key 100)
+    expect(round5Idx).toBeLessThan(groupIdx);
+    expect(groupIdx).toBeLessThan(finalsIdx);
+  });
+
+  it("sorts 'Quarter-Final' (key 80) between semi-finals and regular rounds", () => {
+    useTournamentStore.setState({
+      rounds: [
+        makeRound("r-semi", "Semi-Final"),
+        makeRound("r-quarter", "Quarter-Final"),
+        makeRound("r-round1", "Round 1"),
+      ],
+    });
+
+    useTournamentStore.getState().addRound();
+
+    const titles = useTournamentStore.getState().rounds.map((r) => r.title);
+    const quarterIdx = titles.indexOf("Quarter-Final");
+    const semiIdx = titles.indexOf("Semi-Final");
+    const round1Idx = titles.indexOf("Round 1");
+
+    // Round 1 (11) < Quarter-Final (80) < Semi-Final (90)
+    expect(round1Idx).toBeLessThan(quarterIdx);
+    expect(quarterIdx).toBeLessThan(semiIdx);
+  });
+
+  it("resetBracket resets to default state with all default rounds", () => {
+    useTournamentStore.getState().addRound();
+    useTournamentStore.getState().resetBracket();
+    const state = useTournamentStore.getState();
+    // Default has Round 1, Semi-Finals, Finals
+    const titles = state.rounds.map((r) => r.title);
+    expect(titles).toContain("Round 1");
+    expect(titles.some((t) => t.toLowerCase().includes("final"))).toBe(true);
+  });
+});

--- a/client-app/src/tests/stores/userStoreExtended.test.ts
+++ b/client-app/src/tests/stores/userStoreExtended.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useUserStore } from "@/shared/stores/userStore";
+
+describe("userStore - isGuestUser", () => {
+  beforeEach(() => {
+    useUserStore.getState().clearUser();
+  });
+
+  it("isGuestUser returns false when user is not a guest", () => {
+    const { setUser, isGuestUser } = useUserStore.getState();
+    setUser({ id: "u1", isGuest: false });
+    expect(isGuestUser()).toBe(false);
+  });
+
+  it("isGuestUser returns true when user.isGuest is true", () => {
+    const { setUser, isGuestUser } = useUserStore.getState();
+    setUser({ id: "guest-1", isGuest: true });
+    expect(isGuestUser()).toBe(true);
+  });
+
+  it("isGuestUser returns false when user is not set (default state)", () => {
+    const { isGuestUser } = useUserStore.getState();
+    expect(isGuestUser()).toBe(false);
+  });
+
+  it("isSessionExpired returns false when expiresAt is not set", () => {
+    const { setUser, isSessionExpired } = useUserStore.getState();
+    setUser({ id: "u1" }); // no expiresAt
+    expect(isSessionExpired()).toBe(false);
+  });
+
+  it("isSessionExpired returns true when expiresAt is in the past", () => {
+    const { setUser, isSessionExpired } = useUserStore.getState();
+    setUser({ id: "u1", expiresAt: Date.now() - 5000 });
+    expect(isSessionExpired()).toBe(true);
+  });
+
+  it("isSessionExpired returns false when expiresAt is in the future", () => {
+    const { setUser, isSessionExpired } = useUserStore.getState();
+    setUser({ id: "u1", expiresAt: Date.now() + 5000 });
+    expect(isSessionExpired()).toBe(false);
+  });
+
+  it("isAuthenticated returns false when not authenticated", () => {
+    const { isAuthenticated } = useUserStore.getState();
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it("isAuthenticated clears user and returns false when session is expired", () => {
+    const { setUser, isAuthenticated } = useUserStore.getState();
+    setUser({ id: "u1", expiresAt: Date.now() - 1000 });
+    const result = isAuthenticated();
+    expect(result).toBe(false);
+    expect(useUserStore.getState().user.id).toBe("");
+  });
+});

--- a/server-app/src/tests/env-production.test.js
+++ b/server-app/src/tests/env-production.test.js
@@ -1,0 +1,47 @@
+// Tests the production and test branches of env.js.
+// Must run in its own file so NODE_ENV can be set before module import.
+
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+// Set to production before importing env.js so the production branch is taken
+process.env.NODE_ENV = "production";
+process.env.PORT = "8080";
+process.env.MONGO_URI = "mongodb://prod-host:27017/prod_db";
+process.env.JWT_SECRET = "prod-jwt-secret";
+process.env.SESSION_SECRET = "prod-session-secret";
+process.env.BASE_URL = "https://prod.example.com";
+process.env.CLIENT_URL = "https://app.example.com";
+process.env.RESEND_API_KEY = "resend-prod-key";
+
+const envModule = await import("../infrastructure/config/env.js");
+
+describe("env.js – production branch", () => {
+  it("exports port from production config", () => {
+    assert.strictEqual(envModule.port, "8080");
+  });
+
+  it("exports mongoUri from production config", () => {
+    assert.strictEqual(envModule.mongoUri, "mongodb://prod-host:27017/prod_db");
+  });
+
+  it("exports jwtSecret from production config", () => {
+    assert.strictEqual(envModule.jwtSecret, "prod-jwt-secret");
+  });
+
+  it("exports sessionSecret from production config", () => {
+    assert.strictEqual(envModule.sessionSecret, "prod-session-secret");
+  });
+
+  it("exports baseUrl from production config", () => {
+    assert.strictEqual(envModule.baseUrl, "https://prod.example.com");
+  });
+
+  it("exports clientUrl from production config", () => {
+    assert.strictEqual(envModule.clientUrl, "https://app.example.com");
+  });
+
+  it("exports resendApiKey from production config", () => {
+    assert.strictEqual(envModule.resendApiKey, "resend-prod-key");
+  });
+});

--- a/server-app/src/tests/services/logger-axiom.test.js
+++ b/server-app/src/tests/services/logger-axiom.test.js
@@ -1,0 +1,86 @@
+// Tests the Axiom transport branch (lines 60-66) in logger.js.
+// This file runs in its own module scope so it can import a fresh logger
+// with AXIOM_TOKEN and AXIOM_DATASET env vars set.
+
+import assert from "node:assert";
+import { describe, it, mock } from "node:test";
+
+// Set env vars BEFORE any imports so the module reads them at load time
+process.env.AXIOM_TOKEN = "test-axiom-token";
+process.env.AXIOM_DATASET = "test-axiom-dataset";
+process.env.NODE_ENV = "production";
+
+const pushMock = mock.fn();
+
+const mockAxiomTransportClass = class MockAxiomTransport {
+  constructor(opts) {
+    this.opts = opts;
+  }
+};
+
+// Mock @axiomhq/winston so we don't actually connect to Axiom
+mock.module("@axiomhq/winston", {
+  namedExports: {
+    WinstonTransport: mockAxiomTransportClass,
+  },
+});
+
+const mockCreateLogger = mock.fn((opts) => ({
+  level: opts.level,
+  transports: opts.transports,
+  error: mock.fn(),
+  warn: mock.fn(),
+  info: mock.fn(),
+}));
+
+mock.module("winston", {
+  defaultExport: {
+    addColors: mock.fn(),
+    createLogger: mockCreateLogger,
+    format: {
+      combine: mock.fn((...args) => args),
+      timestamp: mock.fn(() => ({})),
+      colorize: mock.fn(() => ({})),
+      printf: mock.fn(() => ({})),
+    },
+    transports: {
+      Console: class MockConsole {},
+      File: class MockFile {},
+    },
+  },
+});
+
+// Import the logger AFTER mocks are set up
+const { default: logger } = await import("../../infrastructure/utils/logger.js");
+
+describe("logger – Axiom transport branch", () => {
+  it("adds an AxiomTransport when AXIOM_TOKEN and AXIOM_DATASET are set", () => {
+    assert.ok(mockCreateLogger.mock.calls.length >= 1, "createLogger should have been called");
+    const callArgs = mockCreateLogger.mock.calls[0].arguments[0];
+    const transports = callArgs.transports;
+
+    // At least one transport should be an instance of our MockAxiomTransport
+    const axiomTransport = transports.find((t) => t instanceof mockAxiomTransportClass);
+    assert.ok(axiomTransport, "AxiomTransport should be in the transports list");
+  });
+
+  it("initialises Axiom transport with correct token and dataset", () => {
+    const callArgs = mockCreateLogger.mock.calls[0].arguments[0];
+    const transports = callArgs.transports;
+    const axiomTransport = transports.find((t) => t instanceof mockAxiomTransportClass);
+
+    assert.strictEqual(axiomTransport.opts.token, "test-axiom-token");
+    assert.strictEqual(axiomTransport.opts.dataset, "test-axiom-dataset");
+  });
+
+  it("logger level is 'info' in production environment", () => {
+    const callArgs = mockCreateLogger.mock.calls[0].arguments[0];
+    assert.strictEqual(callArgs.level, "info");
+  });
+
+  it("logger exposes standard log methods", () => {
+    assert.strictEqual(typeof logger.error, "function");
+    assert.strictEqual(typeof logger.warn, "function");
+    assert.strictEqual(typeof logger.info, "function");
+  });
+});


### PR DESCRIPTION
## Summary

- **userStore** (`userStoreExtended.test.ts`): covers `isGuestUser()`, `isSessionExpired()`, and `isAuthenticated()` edge cases (expired session clears user, default false, future/past timestamps)
- **tournamentStore** (`tournamentStoreRoundSortKey.test.ts`): covers `getRoundSortKey` indirectly via `sortRounds` — verifies Bronze Final (99), 3rd Place (99), Quarter-Final (80), and unmatched title (50) sort keys produce correct round ordering
- **TournamentBracket** (`TournamentBracketExtended.test.tsx`): covers `onRemoveParticipantFromSlot` — clicking the "×" remove button sets `participant1Id`/`participant2Id` to null in the store
- **logger.js** (`logger-axiom.test.js`): covers the Axiom transport branch — when `AXIOM_TOKEN` and `AXIOM_DATASET` are set, `WinstonTransport` is instantiated with the correct credentials and added to the transports list
- **env.js** (`env-production.test.js`): covers the production config branch — all 7 exported values (`port`, `mongoUri`, `jwtSecret`, `sessionSecret`, `baseUrl`, `clientUrl`, `resendApiKey`) are read from env vars

## Test plan

- [ ] `npm run test:client` — all Vitest tests pass including new files
- [ ] `npm run test:server` — all Node test runner tests pass including new files
- [ ] Server coverage: `logger.js` 100%, `env.js` production branch covered

https://claude.ai/code/session_01JdEz2RAd55YFhtD2ddfm5b

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdEz2RAd55YFhtD2ddfm5b)_