### PR TITLE
Add antique gold accent via blue palette remap

### DIFF
--- a/client-app/src/shared/ui/AppShell.tsx
+++ b/client-app/src/shared/ui/AppShell.tsx
@@ -69,6 +69,7 @@ const AppShell: React.FC<AppShellProps> = ({ children }) => {
             fontWeight="medium"
             textAlign={isPortrait ? "left" : "center"}
             flex="1"
+            color="blue.fg"
           >
             {isPortrait ? "TW Tournament" : "Total Warhammer Tournament App"}
             {isUserGuest && !isPortrait && (

--- a/client-app/src/shared/ui/theme.ts
+++ b/client-app/src/shared/ui/theme.ts
@@ -1,11 +1,39 @@
 import { createSystem, defaultConfig, defineConfig } from "@chakra-ui/react";
 
-// Light: green body/nav bg + white panels (contrast), crimson borders throughout
-// Dark: deep forest-green bg + white/pale panels, dark crimson borders
+// Remap the `blue` palette to antique gold — every colorPalette="blue" component
+// (buttons, badges, active nav, info text) automatically becomes gold-themed with
+// zero component-file changes. Accessibility note: blue.contrast overridden to dark
+// text since gold (#c9a227) is too light for white text (3.2:1 vs required 4.5:1).
+const GOLD = {
+  50: "#fefce8",
+  100: "#fef9c3",
+  200: "#fef08a",
+  300: "#fde047",
+  400: "#facc15",
+  500: "#c9a227", // antique gold — solid button bg
+  600: "#a37d1a", // brass
+  700: "#7d5c10", // dark gold (light-mode fg, readable on green bg)
+  800: "#5a4008",
+  900: "#3d2b04",
+  950: "#231802", // used as contrast text on solid gold buttons
+};
+
 const config = defineConfig({
   theme: {
+    tokens: {
+      colors: {
+        // Override blue → antique gold. All colorPalette="blue" elements become gold.
+        blue: Object.fromEntries(
+          Object.entries(GOLD).map(([k, v]) => [k, { value: v }]),
+        ),
+      },
+    },
     semanticTokens: {
       colors: {
+        // Dark text on solid gold buttons for AA contrast (gold is too light for white)
+        blue: {
+          contrast: { value: "{colors.blue.950}" },
+        },
         bg: {
           // Body background is clearly green — panels (white) float above it
           DEFAULT: {
@@ -33,7 +61,7 @@ const config = defineConfig({
           value: { _light: "#d8e8d8", _dark: "#0c1a10" },
         },
         border: {
-          // All borders are crimson — gives the red presence on every card/input
+          // All borders are crimson — gives red presence on every card/input
           DEFAULT: {
             value: { _light: "#a85050", _dark: "#6e2c2c" },
           },


### PR DESCRIPTION
## Summary

- Remaps Chakra's `blue` token scale to antique gold (`#c9a227` at 500, dark brass through to near-black at 950)
- Because `colorPalette="blue"` and `color="blue.*"` resolve through the token system, **zero component files needed changing** — every primary action button, badge, active nav icon, info text, and focus ring becomes gold automatically
- Overrides `blue.contrast` → `blue.950` (near-black) so text on solid gold buttons maintains AA contrast (gold is too light for white text)
- Adds `color="blue.fg"` to the AppShell header title: dark antique gold in light mode, bright gold in dark mode

## What turns gold automatically

| Element | Token used | Files changed |
|---|---|---|
| All primary action buttons | `colorPalette="blue"` | 0 |
| Active nav icons & text | `color="blue.500"` in NavItems | 0 |
| Guest Mode badge | `colorPalette="blue"` in AppShell | 0 |
| Info-state text (`blue.fg`) | `color="blue.fg"` | 0 |
| Focus rings on blue-palette elements | `blue.solid` via colorPalette | 0 |
| App header title | explicit `color="blue.fg"` added | AppShell.tsx |

## Test plan

- [ ] Light mode: primary buttons, nav active state, badges should all be antique gold, not blue
- [ ] Dark mode: same — gold should be bright/warm against dark green bg
- [ ] Solid gold buttons should have dark (not white) text — check "View Ongoing Tournaments", "Create Tournament", login/register buttons
- [ ] App title in header should be gold in both modes
- [ ] Run `npx vitest run` in `client-app/` — all 376 tests pass

https://claude.ai/code/session_014MvZ7mQctb8pg9bD8t6KhS

---
_Generated by [Claude Code](https://claude.ai/code/session_014MvZ7mQctb8pg9bD8t6KhS)_