### PR TITLE
Add /t/:code deep-link route for sharing tournaments

### DIFF
--- a/client-app/src/App.tsx
+++ b/client-app/src/App.tsx
@@ -19,6 +19,9 @@ const MatchesPage = lazyLoad(
 const TournamentViewPage = lazyLoad(
   () => import("@/features/tournaments/components/TournamentViewPage"),
 );
+const TournamentByCode = lazyLoad(
+  () => import("@/features/tournaments/components/TournamentByCode"),
+);
 const ContactPage = lazyLoad(
   () => import("@/features/contact/components/ContactPage"),
 );
@@ -44,6 +47,7 @@ export function App() {
             element={<TournamentViewPage />}
           />
           <Route path="/tournament/:id" element={<TournamentViewPage />} />
+          <Route path="/t/:code" element={<TournamentByCode />} />
           <Route path="/matches" element={<MatchesPage />} />
           <Route path="/statistics" element={<StatisticsPage />} />
           <Route path="/account" element={<AccountPage />} />

--- a/client-app/src/features/home/components/TournamentLookup.tsx
+++ b/client-app/src/features/home/components/TournamentLookup.tsx
@@ -19,6 +19,7 @@ import { useUserStore } from "@/shared/stores/userStore";
 
 interface ActiveTournament {
   _id: string;
+  code?: string;
   name: string;
   tournamentType: string;
   playerCount: number;
@@ -70,7 +71,7 @@ const TournamentLookup: React.FC = () => {
       if (isParticipant) {
         navigate(`/matches#${t._id}`);
       } else {
-        navigate(`/matches/spectate/${t._id}`);
+        navigate(`/t/${trimmed}`);
       }
     } catch {
       setCodeError("No tournament found with that code.");
@@ -199,7 +200,7 @@ const TournamentLookup: React.FC = () => {
                         size="xs"
                         variant="outline"
                         flexShrink={0}
-                        onClick={() => navigate(`/matches/spectate/${t._id}`)}
+                        onClick={() => navigate(t.code ? `/t/${t.code}` : `/tournament/${t._id}`)}
                       >
                         <LuEye /> View
                       </Button>

--- a/client-app/src/features/matches/components/MatchesPage.tsx
+++ b/client-app/src/features/matches/components/MatchesPage.tsx
@@ -143,7 +143,7 @@ const MatchesPage: React.FC = () => {
       const isParticipant = t.participants?.some(
         (p) => p.name.trim().toLowerCase() === lowerName || p.name === user?.id,
       );
-      navigate(isParticipant ? `#${t._id}` : `/matches/spectate/${t._id}`);
+      navigate(isParticipant ? `#${t._id}` : `/t/${code}`);
       setCodeInput("");
     } catch {
       setCodeError("No tournament found with that code.");

--- a/client-app/src/features/tournaments/components/TournamentBrowser.tsx
+++ b/client-app/src/features/tournaments/components/TournamentBrowser.tsx
@@ -49,6 +49,7 @@ interface Participant {
 
 interface Tournament {
   _id: string;
+  code?: string;
   name: string;
   description: string;
   playerCount: number;
@@ -298,7 +299,13 @@ const TournamentBrowser: React.FC<Props> = ({ statusFilter, emptyMessage }) => {
                         variant="outline"
                         size="sm"
                         colorPalette="verdigris"
-                        onClick={() => navigate(`/matches/spectate/${t._id}`)}
+                        onClick={() =>
+                          navigate(
+                            t.code
+                              ? `/t/${t.code}`
+                              : `/tournament/${t._id}`,
+                          )
+                        }
                       >
                         {t.status === "completed" ? <LuTrophy /> : <LuEye />}
                         {t.status === "completed" ? "View Results" : "Spectate"}

--- a/client-app/src/features/tournaments/components/TournamentByCode.tsx
+++ b/client-app/src/features/tournaments/components/TournamentByCode.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { Box, Spinner, Text, VStack, Button } from "@chakra-ui/react";
+import { httpClient } from "@/core/api/httpClient";
+
+const TournamentByCode: React.FC = () => {
+  const { code } = useParams<{ code: string }>();
+  const navigate = useNavigate();
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!code) return;
+    httpClient
+      .get<{ success: boolean; data: { _id: string } }>(
+        `/tournament/code/${code.toUpperCase()}`,
+      )
+      .then((res) => {
+        navigate(`/tournament/${res.data._id}`, { replace: true });
+      })
+      .catch(() => {
+        setNotFound(true);
+      });
+  }, [code, navigate]);
+
+  if (notFound) {
+    return (
+      <Box textAlign="center" py={20}>
+        <VStack gap={4}>
+          <Text fontSize="2xl" fontWeight="bold" fontFamily="heading">
+            Tournament Not Found
+          </Text>
+          <Text color="fg.muted">
+            No tournament with code{" "}
+            <Text as="span" fontFamily="mono" fontWeight="bold">
+              {code?.toUpperCase()}
+            </Text>{" "}
+            exists.
+          </Text>
+          <Button colorPalette="verdigris" variant="outline" asChild>
+            <Link to="/tournaments">Browse Tournaments</Link>
+          </Button>
+        </VStack>
+      </Box>
+    );
+  }
+
+  return (
+    <Box display="flex" justifyContent="center" alignItems="center" py={20}>
+      <Spinner size="lg" />
+    </Box>
+  );
+};
+
+export default TournamentByCode;

--- a/client-app/src/features/tournaments/components/TournamentsPage.tsx
+++ b/client-app/src/features/tournaments/components/TournamentsPage.tsx
@@ -113,7 +113,7 @@ const TournamentsPage: React.FC = () => {
       if (isParticipant) {
         navigate(`/matches#${t._id}`);
       } else {
-        navigate(`/matches/spectate/${t._id}`);
+        navigate(`/t/${code}`);
       }
     } catch {
       setCodeError("No tournament found with that code.");

--- a/client-app/src/tests/features/TournamentBrowser.test.tsx
+++ b/client-app/src/tests/features/TournamentBrowser.test.tsx
@@ -329,13 +329,14 @@ describe("TournamentBrowser", () => {
     );
   });
 
-  it("navigates to spectate on Spectate click", async () => {
+  it("navigates to /t/:code on Spectate click when code is present", async () => {
     const user = userEvent.setup();
     mockGet.mockResolvedValue({
       success: true,
       data: [
         makeTournament({
           _id: "t99",
+          code: "SPEC99",
           status: "active",
           playerCount: 8,
           participants: [],
@@ -345,7 +346,7 @@ describe("TournamentBrowser", () => {
     renderBrowser({ statusFilter: "active" });
     await waitFor(() => screen.getByRole("button", { name: /spectate/i }));
     await user.click(screen.getByRole("button", { name: /spectate/i }));
-    expect(mockNavigate).toHaveBeenCalledWith("/matches/spectate/t99");
+    expect(mockNavigate).toHaveBeenCalledWith("/t/SPEC99");
   });
 
   it("shows Participated badge for completed joined tournament", async () => {

--- a/client-app/src/tests/features/TournamentsPageExtended.test.tsx
+++ b/client-app/src/tests/features/TournamentsPageExtended.test.tsx
@@ -174,7 +174,7 @@ describe("TournamentsPage – code search", () => {
     });
   });
 
-  it("navigates to spectate when user is not a participant", async () => {
+  it("navigates to /t/:code when user is not a participant", async () => {
     mockGet.mockResolvedValueOnce({
       success: true,
       data: {
@@ -189,7 +189,7 @@ describe("TournamentsPage – code search", () => {
       screen.getByRole("button", { name: /find tournament/i }),
     );
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/matches/spectate/t88");
+      expect(mockNavigate).toHaveBeenCalledWith("/t/VALIDCODE");
     });
   });
 

--- a/client-app/src/tests/features/home/TournamentLookup.test.tsx
+++ b/client-app/src/tests/features/home/TournamentLookup.test.tsx
@@ -88,7 +88,7 @@ describe("TournamentLookup", () => {
     });
   });
 
-  it("navigates to spectate when user is not a participant", async () => {
+  it("navigates to /t/:code when user is not a participant", async () => {
     mockGet
       .mockResolvedValueOnce({ success: true, data: [] })
       .mockResolvedValueOnce({
@@ -107,7 +107,7 @@ describe("TournamentLookup", () => {
     );
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/matches/spectate/t123");
+      expect(mockNavigate).toHaveBeenCalledWith("/t/ABC123");
     });
   });
 

--- a/client-app/src/tests/features/home/TournamentLookupExtended.test.tsx
+++ b/client-app/src/tests/features/home/TournamentLookupExtended.test.tsx
@@ -51,12 +51,13 @@ describe("TournamentLookup – View button navigation", () => {
     mockNavigate.mockReset();
   });
 
-  it("navigates to spectate page when View button is clicked", async () => {
+  it("navigates to /t/:code when View button is clicked and code is present", async () => {
     mockGet.mockResolvedValue({
       success: true,
       data: [
         {
           _id: "t42",
+          code: "CUP42",
           name: "Battle Cup",
           tournamentType: "Single Elimination",
           playerCount: 8,
@@ -80,16 +81,17 @@ describe("TournamentLookup – View button navigation", () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/matches/spectate/t42");
+      expect(mockNavigate).toHaveBeenCalledWith("/t/CUP42");
     });
   });
 
-  it("navigates to correct tournament spectate page with multiple tournaments", async () => {
+  it("navigates to correct /t/:code with multiple tournaments", async () => {
     mockGet.mockResolvedValue({
       success: true,
       data: [
         {
           _id: "t1",
+          code: "CUPA1",
           name: "Cup A",
           tournamentType: "Round Robin",
           playerCount: 4,
@@ -98,6 +100,7 @@ describe("TournamentLookup – View button navigation", () => {
         },
         {
           _id: "t2",
+          code: "CUPB2",
           name: "Cup B",
           tournamentType: "Round Robin",
           playerCount: 4,
@@ -119,7 +122,7 @@ describe("TournamentLookup – View button navigation", () => {
     if (viewBtns.length >= 2) {
       await userEvent.click(viewBtns[1]);
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith("/matches/spectate/t2");
+        expect(mockNavigate).toHaveBeenCalledWith("/t/CUPB2");
       });
     } else {
       // If only one is rendered (layout limit), just verify the structure


### PR DESCRIPTION
## Summary

Organizers couldn't share a tournament URL — the only way to navigate to a specific tournament was through the in-app code lookup, and the resulting URLs contained raw MongoDB GUIDs. This adds `/t/:code` as a clean, shareable entry point.

- **New `TournamentByCode` component** — handles `/t/:code`, calls `GET /tournament/code/:code` (already existed on the server), then redirects to `/tournament/:id` with `replace: true`. Shows a "Tournament Not Found" error state for invalid codes.
- **New `/t/:code` route** in `App.tsx` (lazy-loaded like all other pages)
- **Code-lookup forms updated** — `TournamentLookup`, `TournamentsPage`, and `MatchesPage` all redirect non-participants to `/t/:code` after a successful code lookup, so the clean URL is what ends up in the browser bar
- **Tournament list buttons updated** — `TournamentBrowser` "Spectate/View Results" and `TournamentLookup` "View" buttons use `/t/:code` when the code is present in the API response (fallback to `/tournament/:id` for any old tournaments without a code)

No server changes needed — `GET /tournament/code/:code` was already implemented.

## Test plan

- [ ] Navigate directly to `/t/SOMEVALIDCODE` — should resolve and land on the tournament page
- [ ] Navigate to `/t/BADCODE` — should show "Tournament Not Found" with a link to browse tournaments
- [ ] Code lookup form (home page, tournaments page, matches page): enter a code as a non-participant → browser bar shows `/t/:code` after redirect
- [ ] Code lookup form as a participant → still redirects to `/matches#:id` (unchanged)
- [ ] "Spectate/View Results" in tournament browser uses `/t/:code` URL
- [ ] Build passes, all 376 tests pass

https://claude.ai/code/session_01As9ow5wQeedGc4HB7wfDQo

---
_Generated by [Claude Code](https://claude.ai/code/session_01As9ow5wQeedGc4HB7wfDQo)_