### PR TITLE
Keep /t/:code URL persistent in browser bar

### DIFF
--- a/client-app/src/features/tournaments/components/TournamentByCode.tsx
+++ b/client-app/src/features/tournaments/components/TournamentByCode.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import { Box, Spinner, Text, VStack, Button } from "@chakra-ui/react";
 import { httpClient } from "@/core/api/httpClient";
+import TournamentViewPage from "./TournamentViewPage";
 
 const TournamentByCode: React.FC = () => {
   const { code } = useParams<{ code: string }>();
-  const navigate = useNavigate();
+  const [resolvedId, setResolvedId] = useState<string | null>(null);
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {
@@ -14,13 +15,9 @@ const TournamentByCode: React.FC = () => {
       .get<{ success: boolean; data: { _id: string } }>(
         `/tournament/code/${code.toUpperCase()}`,
       )
-      .then((res) => {
-        navigate(`/tournament/${res.data._id}`, { replace: true });
-      })
-      .catch(() => {
-        setNotFound(true);
-      });
-  }, [code, navigate]);
+      .then((res) => setResolvedId(res.data._id))
+      .catch(() => setNotFound(true));
+  }, [code]);
 
   if (notFound) {
     return (
@@ -44,11 +41,15 @@ const TournamentByCode: React.FC = () => {
     );
   }
 
-  return (
-    <Box display="flex" justifyContent="center" alignItems="center" py={20}>
-      <Spinner size="lg" />
-    </Box>
-  );
+  if (!resolvedId) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" py={20}>
+        <Spinner size="lg" />
+      </Box>
+    );
+  }
+
+  return <TournamentViewPage id={resolvedId} />;
 };
 
 export default TournamentByCode;

--- a/client-app/src/features/tournaments/components/TournamentViewPage.tsx
+++ b/client-app/src/features/tournaments/components/TournamentViewPage.tsx
@@ -84,8 +84,9 @@ interface Tournament {
   createdBy: string;
 }
 
-const TournamentViewPage: React.FC = () => {
-  const { id } = useParams<{ id: string }>();
+const TournamentViewPage: React.FC<{ id?: string }> = ({ id: propId }) => {
+  const { id: paramId } = useParams<{ id: string }>();
+  const id = propId ?? paramId;
   const navigate = useNavigate();
   const { user, isAuthenticated } = useUserStore();
 


### PR DESCRIPTION
## Problem

After the previous PR, visiting `/t/CODE` briefly showed the code URL before redirecting to `/tournament/<guid>`. The clean URL disappeared immediately.

## Fix

Instead of resolving the code and then navigating away, `TournamentByCode` now renders `TournamentViewPage` in-place with the resolved ID passed as a prop. The `/t/:code` URL stays in the browser bar permanently.

**`TournamentViewPage`** gets a minimal change: accepts an optional `id` prop that takes precedence over `useParams`. The existing `/tournament/:id` route is completely unaffected.

**`TournamentByCode`** no longer calls `navigate()` — it fetches the ID, then renders `<TournamentViewPage id={resolvedId} />` directly.

## Verified end-to-end

- `/t/:code` → loads tournament, URL stays as `/t/:code` ✓
- `/tournament/:id` → unaffected, still works via `useParams` ✓
- Code lookup (3 places) → non-participants land at `/t/:code` ✓
- Participants → still go to `/matches#:id` ✓
- Tournament list "Spectate/View" buttons → use `/t/:code` when code present, fall back to `/tournament/:id` ✓
- 376 tests pass ✓

https://claude.ai/code/session_01As9ow5wQeedGc4HB7wfDQo

---
_Generated by [Claude Code](https://claude.ai/code/session_01As9ow5wQeedGc4HB7wfDQo)_