### PR TITLE
test: achieve 100% unit test coverage (batch 3)

### DIFF
--- a/client-app/src/features/tournaments/components/TournamentsPage.tsx
+++ b/client-app/src/features/tournaments/components/TournamentsPage.tsx
@@ -151,8 +151,8 @@ const TournamentsPage: React.FC = () => {
 
     window.addEventListener("hashchange", handleHashChange);
 
+    /* c8 ignore next 3 — Effect 1 always sets the hash before this Effect 2 check runs */
     if (window.location.hash.replace("#", "") !== activeTab) {
-      /* c8 ignore next — Effect 1 always sets the hash before this Effect 2 check runs */
       window.location.hash = `#${activeTab}`;
     }
 

--- a/client-app/src/features/tournaments/components/TournamentsPage.tsx
+++ b/client-app/src/features/tournaments/components/TournamentsPage.tsx
@@ -152,6 +152,7 @@ const TournamentsPage: React.FC = () => {
     window.addEventListener("hashchange", handleHashChange);
 
     if (window.location.hash.replace("#", "") !== activeTab) {
+      /* c8 ignore next — Effect 1 always sets the hash before this Effect 2 check runs */
       window.location.hash = `#${activeTab}`;
     }
 

--- a/client-app/src/tests/core/httpClientPutBranchCoverage.test.ts
+++ b/client-app/src/tests/core/httpClientPutBranchCoverage.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Branch coverage for httpClient.ts PUT method and POST retry:
+ * - Line 180: POST retry `body: data ? ... : undefined` — no-body (data=undefined) false branch
+ * - Line 227: PUT `body: data ? ... : undefined` — no-body false branch
+ * - Line 234: PUT `if (errorData.error === "CSRF validation failed")` — false branch (different error)
+ * - Line 249: PUT retry `body: data ? ... : undefined` — no-body false branch
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { httpClient } from "@/core/api/httpClient";
+import { apiConfig } from "@/core/config/apiConfig";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const baseUrl = apiConfig.baseUrl || "http://localhost:3000";
+
+describe("httpClient – PUT / POST retry branch coverage", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    httpClient.resetCsrfToken();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("POST retry with undefined data (line 180 false branch)", () => {
+    it("retries POST without body when data is undefined", async () => {
+      // CSRF token fetch succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "tok-1" }),
+        status: 200,
+      });
+      // POST fails with 403 CSRF error
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "CSRF validation failed" }),
+      });
+      // CSRF token refresh
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "tok-2" }),
+        status: 200,
+      });
+      // Retry POST succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ created: true }),
+        headers: new Headers({ "content-length": "15" }),
+      });
+
+      // Call post with NO data argument → data is undefined → false branch of `data ?`
+      const result = await httpClient.post("/no-body-endpoint");
+
+      expect(result).toEqual({ created: true });
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      // Retry call (index 3) should have undefined body
+      expect(mockFetch.mock.calls[3][1].body).toBeUndefined();
+    });
+  });
+
+  describe("PUT – no-body (line 227 false branch)", () => {
+    it("sends PUT request with undefined body when data is omitted", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "put-tok" }),
+        status: 200,
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ updated: true }),
+        headers: new Headers({ "content-length": "15" }),
+      });
+
+      const result = await httpClient.put("/resource/1");
+
+      expect(result).toEqual({ updated: true });
+      // body should be undefined when no data is passed
+      expect(mockFetch.mock.calls[1][1].body).toBeUndefined();
+    });
+  });
+
+  describe("PUT – 403 non-CSRF error (line 234 false branch)", () => {
+    it("does not retry PUT when 403 error is not CSRF-related", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "put-tok" }),
+        status: 200,
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "Unauthorized", message: "Access denied" }),
+      });
+
+      // Should throw from handleResponse (no retry)
+      await expect(httpClient.put("/protected", { x: 1 })).rejects.toThrow();
+
+      // Only 2 calls: CSRF fetch + PUT request (no retry)
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("PUT – retry with undefined data (line 249 false branch)", () => {
+    it("retries PUT without body when data is undefined and CSRF fails", async () => {
+      // CSRF token fetch
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "old-put-tok" }),
+        status: 200,
+      });
+      // PUT fails with 403 CSRF error
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "CSRF validation failed" }),
+      });
+      // CSRF token refresh
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "new-put-tok" }),
+        status: 200,
+      });
+      // Retry PUT succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+        headers: new Headers({ "content-length": "2" }),
+      });
+
+      // No data argument → body should be undefined in retry
+      await httpClient.put("/resource/1");
+
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      // Retry request (index 3) should have undefined body
+      expect(mockFetch.mock.calls[3][1].body).toBeUndefined();
+    });
+  });
+
+  describe("PUT – with CSRF token (happy path verification)", () => {
+    it("makes PUT request with CSRF token and body", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrfToken: "happy-tok" }),
+        status: 200,
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ saved: true }),
+        headers: new Headers({ "content-length": "12" }),
+      });
+
+      const result = await httpClient.put("/resource/1", { name: "Updated" });
+
+      expect(result).toEqual({ saved: true });
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        `${baseUrl}/resource/1`,
+        expect.objectContaining({
+          method: "PUT",
+          headers: expect.objectContaining({ "X-CSRF-Token": "happy-tok" }),
+          body: JSON.stringify({ name: "Updated" }),
+        }),
+      );
+    });
+  });
+});

--- a/client-app/src/tests/features/CreateTournamentFormNavigate.test.tsx
+++ b/client-app/src/tests/features/CreateTournamentFormNavigate.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Branch coverage for CreateTournamentForm.tsx line 148:
+ *   `onClick: () => navigate(\`/matches/tournament/${response.data.code}\`)`
+ *
+ * The toast action's onClick callback is never directly tested in existing tests
+ * (toaster is mocked, so the action is captured but never invoked).
+ * This test extracts the callback from toaster.create's captured arguments
+ * and calls it to verify navigate is called with the correct path.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: vi.fn() },
+}));
+
+vi.mock("@/shared/ui/NumberInput", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  NumberInputRoot: ({ children, onValueChange }: any) => (
+    <div
+      data-testid="number-input-root"
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+        onValueChange({ value: e.target.value })
+      }
+    >
+      {children}
+    </div>
+  ),
+  NumberInputField: () => <input data-testid="number-input-field" />,
+}));
+
+import { toaster } from "@/shared/ui/Toaster";
+import { httpClient } from "@/core/api/httpClient";
+import CreateTournamentForm from "@/features/tournaments/components/CreateTournamentForm";
+
+const mockPost = vi.mocked(httpClient.post);
+const mockToasterCreate = vi.mocked(toaster.create);
+
+function renderForm() {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <CreateTournamentForm />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("CreateTournamentForm – toast action navigate (line 148)", () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockToasterCreate.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it("toast action onClick navigates to tournament matches page (line 148)", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { _id: "t1", name: "Battle Cup", code: "BTC123" },
+    });
+
+    renderForm();
+
+    await fireEvent.submit(
+      screen.getByRole("button", { name: /create tournament/i }).closest("form")!,
+    );
+
+    await waitFor(() => {
+      expect(mockToasterCreate).toHaveBeenCalled();
+    });
+
+    // Extract the action onClick from the captured toaster.create call
+    const createCall = mockToasterCreate.mock.calls[0][0] as {
+      action?: { onClick?: () => void };
+    };
+
+    expect(createCall.action).toBeDefined();
+    expect(createCall.action?.onClick).toBeInstanceOf(Function);
+
+    // Invoke the callback — this is the branch at line 148
+    createCall.action!.onClick!();
+
+    expect(mockNavigate).toHaveBeenCalledWith("/matches/tournament/BTC123");
+  });
+
+  it("toast action navigate uses the code from the response", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { _id: "t2", name: "Other Cup", code: "OTH999" },
+    });
+
+    renderForm();
+
+    await fireEvent.submit(
+      screen.getByRole("button", { name: /create tournament/i }).closest("form")!,
+    );
+
+    await waitFor(() => {
+      expect(mockToasterCreate).toHaveBeenCalled();
+    });
+
+    const createCall = mockToasterCreate.mock.calls[0][0] as {
+      action?: { onClick?: () => void };
+    };
+    createCall.action!.onClick!();
+
+    expect(mockNavigate).toHaveBeenCalledWith("/matches/tournament/OTH999");
+  });
+});

--- a/client-app/src/tests/features/TournamentBrowserNullUser.test.tsx
+++ b/client-app/src/tests/features/TournamentBrowserNullUser.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Branch coverage for TournamentBrowser.tsx line 109:
+ *   `if (!user) return false`
+ *
+ * When the user store returns user=null, isAlreadyJoined returns false immediately,
+ * covering the early-return branch at line 109.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+import TournamentBrowser from "@/features/tournaments/components/TournamentBrowser";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { get: vi.fn() },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: vi.fn(),
+}));
+
+import { httpClient } from "@/core/api/httpClient";
+import { useUserStore } from "@/shared/stores/userStore";
+
+const mockGet = vi.mocked(httpClient.get);
+
+function renderBrowser() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <MemoryRouter>
+        <TournamentBrowser statusFilter="active" emptyMessage="No tournaments." />
+      </MemoryRouter>
+    </ChakraProvider>,
+  );
+}
+
+describe("TournamentBrowser – null user branch (line 109)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("isAlreadyJoined returns false when user is null (line 109 true branch)", async () => {
+    vi.mocked(useUserStore as unknown as () => ReturnType<typeof useUserStore>).mockReturnValue(
+      {
+        user: null as unknown as ReturnType<typeof useUserStore>["user"],
+        isAuthenticated: vi.fn().mockReturnValue(false),
+      } as ReturnType<typeof useUserStore>,
+    );
+
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          _id: "t-null",
+          name: "Null User Cup",
+          description: "",
+          playerCount: 4,
+          tournamentType: "Round Robin",
+          bannedFactions: [],
+          participants: [{ _id: "p1", name: "OtherPlayer", faction: "Empire" }],
+          status: "active",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    renderBrowser();
+
+    // Tournament should render; with user=null, isAlreadyJoined returns false → Join button shown
+    await waitFor(() => {
+      expect(screen.getByText("Null User Cup")).toBeInTheDocument();
+    });
+
+    // Spectate button confirms isAlreadyJoined returned false (joined=false → shows Spectate, not My Matches)
+    expect(
+      screen.getByRole("button", { name: /spectate/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("isAlreadyJoined returns false and no crash when user is null with no participants", async () => {
+    vi.mocked(useUserStore as unknown as () => ReturnType<typeof useUserStore>).mockReturnValue(
+      {
+        user: null as unknown as ReturnType<typeof useUserStore>["user"],
+        isAuthenticated: vi.fn().mockReturnValue(false),
+      } as ReturnType<typeof useUserStore>,
+    );
+
+    mockGet.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          _id: "t-empty",
+          name: "Empty Cup",
+          description: "",
+          playerCount: 4,
+          tournamentType: "Round Robin",
+          bannedFactions: [],
+          participants: [],
+          status: "active",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    renderBrowser();
+
+    await waitFor(() => {
+      expect(screen.getByText("Empty Cup")).toBeInTheDocument();
+    });
+  });
+});

--- a/client-app/src/tests/stores/tournamentStoreDeleteBranchCoverage.test.ts
+++ b/client-app/src/tests/stores/tournamentStoreDeleteBranchCoverage.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Branch coverage for tournamentStore.ts deleteParticipant (lines 237-241):
+ * - Line 237: `match.participant2Id === participantId ? null : match.participant2Id`
+ *   true branch — when the deleted participant IS in participant2Id slot
+ * - Line 241: `match.winnerId === participantId ? null : match.winnerId`
+ *   true branch — when the deleted participant IS the winner
+ *
+ * Existing tests only delete participant1Id, never participant2Id or winnerId.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { useTournamentStore } from "@/shared/stores/tournamentStore";
+
+describe("tournamentStore – deleteParticipant branch coverage (lines 237-241)", () => {
+  beforeEach(() => {
+    useTournamentStore.getState().resetParticipantsAndBracket();
+  });
+
+  it("clears participant2Id when that slot holds the deleted participant (line 237 true branch)", () => {
+    const store = useTournamentStore.getState();
+    store.addRound();
+
+    const state = useTournamentStore.getState();
+    const [p1, p2] = state.participants;
+    const match = state.rounds[0]?.matches[0];
+
+    if (!match || !p1 || !p2) return;
+
+    // Place p2 into the participant2Id slot
+    store.updateMatchParticipant(match.id, "participant2Id", p2.id);
+
+    // Confirm p2 is in participant2Id slot
+    expect(
+      useTournamentStore.getState().rounds[0].matches[0].participant2Id,
+    ).toBe(p2.id);
+
+    // Delete p2 — this should clear participant2Id (line 237 true branch: null)
+    store.deleteParticipant(p2.id);
+
+    const updatedMatch = useTournamentStore.getState().rounds[0].matches[0];
+    expect(updatedMatch.participant2Id).toBeNull();
+  });
+
+  it("clears winnerId when the deleted participant was the winner (line 241 true branch)", () => {
+    const store = useTournamentStore.getState();
+    store.addRound();
+
+    const state = useTournamentStore.getState();
+    const [p1] = state.participants;
+    const match = state.rounds[0]?.matches[0];
+
+    if (!match || !p1) return;
+
+    // Set p1 as participant and winner (winnerId uses the same dynamic setter)
+    store.updateMatchParticipant(match.id, "participant1Id", p1.id);
+    store.updateMatchParticipant(match.id, "winnerId" as "participant1Id", p1.id);
+
+    // Confirm winnerId is set
+    const matchWithWinner = useTournamentStore.getState().rounds[0].matches[0];
+    expect(matchWithWinner.winnerId).toBe(p1.id);
+
+    // Delete the winner — should clear winnerId (line 241 true branch: null)
+    store.deleteParticipant(p1.id);
+
+    const updatedMatch = useTournamentStore.getState().rounds[0].matches[0];
+    expect(updatedMatch.winnerId).toBeNull();
+  });
+
+  it("keeps participant1Id of other participants when a different participant is deleted (line 233 false branch)", () => {
+    const store = useTournamentStore.getState();
+    store.addRound();
+
+    const state = useTournamentStore.getState();
+    const [p1, p2] = state.participants;
+    const match = state.rounds[0]?.matches[0];
+
+    if (!match || !p1 || !p2) return;
+
+    // Place p1 and p2 into slots
+    store.updateMatchParticipant(match.id, "participant1Id", p1.id);
+    store.updateMatchParticipant(match.id, "participant2Id", p2.id);
+
+    // Delete p2 — p1 should remain in participant1Id
+    store.deleteParticipant(p2.id);
+
+    const updatedMatch = useTournamentStore.getState().rounds[0].matches[0];
+    expect(updatedMatch.participant1Id).toBe(p1.id);
+    expect(updatedMatch.participant2Id).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds branch coverage tests for 5 client-side files, covering gaps missed by existing tests.

### Files covered

- **`httpClient.ts`**: PUT method no-body false branches (lines 180, 227, 249) and PUT 403 non-CSRF error false branch (line 234) — all cases where `data` is `undefined` or the 403 error message doesn't match "CSRF validation failed"
- **`TournamentBrowser.tsx`**: `isAlreadyJoined` early-return when `user` is null (line 109)
- **`tournamentStore.ts`**: `deleteParticipant` clearing `participant2Id` and `winnerId` when those slots hold the deleted participant (lines 237-241)
- **`CreateTournamentForm.tsx`**: Toast action `onClick` callback that navigates to the created tournament (line 148)
- **`TournamentsPage.tsx`**: Add `c8 ignore` to line 155 — `window.location.hash = \`#${activeTab}\`` inside Effect 2 is unreachable because Effect 1 always sets the hash first (both depend on `activeTab`; React runs effects in declaration order)

## Test plan

- [x] All 12 new tests pass across 4 test files
- [x] No existing tests broken

https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm)_