### PR TITLE
test: batch 4 branch coverage — displayName, StatisticsPage, TournamentsPage, CreateTournamentForm, TournamentBrowser

### DIFF
--- a/client-app/src/tests/features/CreateTournamentFormCountAndDesc.test.tsx
+++ b/client-app/src/tests/features/CreateTournamentFormCountAndDesc.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Branch coverage for CreateTournamentForm.tsx:
+ * - Line 121: `parseInt(value) || 2` — false branch when parseInt returns NaN (empty/non-numeric)
+ *   → playerCount falls back to 2
+ * - Line 248: `formData.description.length >= 2000` — true branch
+ *   → character counter text is rendered (color computed at line 248)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: vi.fn() },
+}));
+
+// Mock NumberInputRoot as a controlled input so fireEvent.change invokes onValueChange directly
+vi.mock("@/shared/ui/NumberInput", () => ({
+  NumberInputRoot: ({
+    onValueChange,
+    value,
+  }: {
+    children?: React.ReactNode;
+    onValueChange: (v: { value: string }) => void;
+    value?: string;
+  }) => (
+    <input
+      data-testid="number-input-field"
+      value={value ?? ""}
+      onChange={(e) => onValueChange({ value: e.target.value })}
+    />
+  ),
+  NumberInputField: () => null,
+}));
+
+import { httpClient } from "@/core/api/httpClient";
+import CreateTournamentForm from "@/features/tournaments/components/CreateTournamentForm";
+
+const mockPost = vi.mocked(httpClient.post);
+
+function renderForm() {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <CreateTournamentForm />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("CreateTournamentForm – handleNumberChange NaN fallback (line 121)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({
+      success: true,
+      data: { _id: "t1", name: "Test", code: "TST123" },
+    });
+  });
+
+  it("playerCount falls back to 2 when value is empty string (parseInt returns NaN)", async () => {
+    renderForm();
+
+    // Set name (required field)
+    fireEvent.change(screen.getByPlaceholderText(/enter tournament name/i), {
+      target: { value: "Test Cup", name: "name" },
+    });
+
+    // Trigger handleNumberChange with "" → parseInt("") = NaN → NaN || 2 = 2
+    fireEvent.change(screen.getByTestId("number-input-field"), {
+      target: { value: "" },
+    });
+
+    // Submit and verify playerCount was set to 2 (the fallback)
+    const form = screen
+      .getByRole("button", { name: /create tournament/i })
+      .closest("form")!;
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalled();
+    });
+
+    const [, body] = mockPost.mock.calls[0] as [string, { playerCount: number }];
+    expect(body.playerCount).toBe(2);
+  });
+
+  it("playerCount falls back to 2 when value is non-numeric (parseInt returns NaN)", async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByPlaceholderText(/enter tournament name/i), {
+      target: { value: "Cup", name: "name" },
+    });
+
+    // "abc" → parseInt("abc") = NaN → NaN || 2 = 2
+    fireEvent.change(screen.getByTestId("number-input-field"), {
+      target: { value: "abc" },
+    });
+
+    const form = screen
+      .getByRole("button", { name: /create tournament/i })
+      .closest("form")!;
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalled();
+    });
+
+    const [, body] = mockPost.mock.calls[0] as [string, { playerCount: number }];
+    expect(body.playerCount).toBe(2);
+  });
+});
+
+describe("CreateTournamentForm – description >= 2000 color branch (line 248)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("counter shows 2000/2000 when description is at max length (line 248 true branch)", async () => {
+    renderForm();
+
+    const textarea = screen.getByPlaceholderText(
+      /enter tournament description/i,
+    );
+    fireEvent.change(textarea, { target: { value: "A".repeat(2000) } });
+
+    await waitFor(() => {
+      expect(screen.getByText("2000/2000")).toBeInTheDocument();
+    });
+  });
+
+  it("counter shows n/2000 when description is under max length (line 248 false branch)", async () => {
+    renderForm();
+
+    const textarea = screen.getByPlaceholderText(
+      /enter tournament description/i,
+    );
+    fireEvent.change(textarea, { target: { value: "short" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("5/2000")).toBeInTheDocument();
+    });
+  });
+});

--- a/client-app/src/tests/features/TournamentBrowserUserIdCoverage.test.tsx
+++ b/client-app/src/tests/features/TournamentBrowserUserIdCoverage.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Branch coverage for TournamentBrowser.tsx line 113:
+ *   `if (p.userId) return p.userId === uid`
+ *
+ * True branch: participant has a userId property → match by userId === user.id.
+ * Also covers line 111: `user.username || uid` — when username is absent, uid is used.
+ *
+ * Existing tests only match participants by name. This test provides a participant
+ * with a `userId` field matching the current user's id, triggering the userId branch.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+import TournamentBrowser from "@/features/tournaments/components/TournamentBrowser";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { get: vi.fn() },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: vi.fn(),
+}));
+
+import { httpClient } from "@/core/api/httpClient";
+import { useUserStore } from "@/shared/stores/userStore";
+
+const mockGet = vi.mocked(httpClient.get);
+const mockUseUserStore = vi.mocked(
+  useUserStore as unknown as () => ReturnType<typeof useUserStore>,
+);
+
+function renderBrowser(statusFilter: string = "pending") {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <MemoryRouter>
+        <TournamentBrowser
+          statusFilter={statusFilter as "pending"}
+          emptyMessage="No tournaments."
+        />
+      </MemoryRouter>
+    </ChakraProvider>,
+  );
+}
+
+describe("TournamentBrowser – userId matching (line 113 true branch)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("isAlreadyJoined returns true when participant.userId matches user.id (line 113 true branch)", async () => {
+    mockUseUserStore.mockReturnValue({
+      user: {
+        id: "uid-abc",
+        email: "test@test.com",
+        username: "TestPlayer",
+        isAuthenticated: true,
+        isGuest: false,
+      },
+      isAuthenticated: vi.fn().mockReturnValue(true),
+    } as ReturnType<typeof useUserStore>);
+
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: [
+        {
+          _id: "t-uid",
+          name: "UserId Cup",
+          description: "",
+          playerCount: 8,
+          tournamentType: "Single Elimination",
+          bannedFactions: [],
+          participants: [
+            {
+              _id: "p1",
+              userId: "uid-abc",
+              name: "SomeOtherName",
+              faction: "Empire",
+            },
+          ],
+          status: "pending",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    renderBrowser("pending");
+
+    await waitFor(() => {
+      expect(screen.getByText("UserId Cup")).toBeInTheDocument();
+    });
+
+    // Joined badge should appear because userId matched → isAlreadyJoined = true
+    expect(screen.getByText("Joined")).toBeInTheDocument();
+
+    // My Matches button confirms joined=true path
+    expect(
+      screen.getByRole("button", { name: /my matches/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("isAlreadyJoined returns false when participant.userId does NOT match user.id (line 113 true branch, false result)", async () => {
+    mockUseUserStore.mockReturnValue({
+      user: {
+        id: "uid-abc",
+        email: "test@test.com",
+        username: "TestPlayer",
+        isAuthenticated: true,
+        isGuest: false,
+      },
+      isAuthenticated: vi.fn().mockReturnValue(true),
+    } as ReturnType<typeof useUserStore>);
+
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: [
+        {
+          _id: "t-uid2",
+          name: "Other Cup",
+          description: "",
+          playerCount: 8,
+          tournamentType: "Single Elimination",
+          bannedFactions: [],
+          participants: [
+            {
+              _id: "p2",
+              userId: "uid-DIFFERENT",
+              name: "SomePlayer",
+              faction: "Dwarfs",
+            },
+          ],
+          status: "pending",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    renderBrowser("pending");
+
+    await waitFor(() => {
+      expect(screen.getByText("Other Cup")).toBeInTheDocument();
+    });
+
+    // Not joined — Spectate button should appear instead
+    expect(
+      screen.getByRole("button", { name: /spectate/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("isAlreadyJoined uses uid as name fallback when username is absent (line 111 false branch)", async () => {
+    mockUseUserStore.mockReturnValue({
+      user: {
+        id: "uid-xyz",
+        email: "guest@test.com",
+        username: undefined,
+        isAuthenticated: true,
+        isGuest: false,
+      },
+      isAuthenticated: vi.fn().mockReturnValue(true),
+    } as ReturnType<typeof useUserStore>);
+
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: [
+        {
+          _id: "t-noname",
+          name: "No Username Cup",
+          description: "",
+          playerCount: 4,
+          tournamentType: "Round Robin",
+          bannedFactions: [],
+          participants: [
+            {
+              _id: "p3",
+              name: "uid-xyz",
+              faction: "Empire",
+            },
+          ],
+          status: "pending",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    renderBrowser("pending");
+
+    await waitFor(() => {
+      expect(screen.getByText("No Username Cup")).toBeInTheDocument();
+    });
+
+    // Matched by uid (used as name because username is absent)
+    expect(screen.getByText("Joined")).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/TournamentsPageHashFalseBranch.test.tsx
+++ b/client-app/src/tests/features/TournamentsPageHashFalseBranch.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Branch coverage for TournamentsPage.tsx handleHashChange — line 143:
+ *   `else if (newHash && !tabs.some((tab) => tab.id === newHash) && activeTab !== tabs[0].id)`
+ *
+ * False branch: invalid hash fired while already on tabs[0] (brackets).
+ * When `activeTab === tabs[0].id`, the condition `activeTab !== tabs[0].id` is false,
+ * so the else-if evaluates to false and nothing happens (no state update).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: vi.fn(() => ({
+    user: {
+      isAuthenticated: false,
+      isGuest: false,
+      username: "TestUser",
+      id: "uid1",
+    },
+  })),
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("@/shared/ui/NumberInput", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  NumberInputRoot: ({ children }: any) => <div>{children}</div>,
+  NumberInputField: () => <input />,
+}));
+
+import TournamentsPage from "@/features/tournaments/components/TournamentsPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <TournamentsPage />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("TournamentsPage – handleHashChange line 143 false branch", () => {
+  beforeEach(() => {
+    // Reset hash to ensure we start on first tab (brackets)
+    window.location.hash = "#brackets";
+  });
+
+  it("does nothing when invalid hash fires and activeTab is already tabs[0] (line 143 false branch)", async () => {
+    renderPage();
+
+    // Page starts on first tab (brackets) — activeTab === tabs[0].id
+    expect(
+      screen.getByText(/create a simple bracket/i),
+    ).toBeInTheDocument();
+
+    // Fire hashchange with an invalid tab id while already on brackets tab
+    await act(async () => {
+      window.location.hash = "#invalid-nonexistent-tab";
+      window.dispatchEvent(new Event("hashchange"));
+    });
+
+    // Component should still show first tab content — no state change occurred
+    // because the else-if at line 143 was false (activeTab === tabs[0].id)
+    expect(
+      screen.getByText(/create a simple bracket/i),
+    ).toBeInTheDocument();
+  });
+
+  it("resets to first tab when invalid hash fires and activeTab is NOT tabs[0] (line 143 true branch)", async () => {
+    renderPage();
+
+    // Switch to a different tab first
+    await act(async () => {
+      window.location.hash = "#createTournament";
+      window.dispatchEvent(new Event("hashchange"));
+    });
+
+    // Now activeTab is createTournament (not tabs[0])
+    // Fire another hashchange with invalid hash
+    await act(async () => {
+      window.location.hash = "#totally-invalid";
+      window.dispatchEvent(new Event("hashchange"));
+    });
+
+    // The else-if at line 143 should now be true → setActiveTab(tabs[0].id)
+    // So brackets content should be visible again
+    expect(
+      screen.getByText(/create a simple bracket/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/statistics/StatisticsPage.test.tsx
+++ b/client-app/src/tests/features/statistics/StatisticsPage.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * Branch coverage for StatisticsPage.tsx.
+ * Covers: loading state, error branches (Error vs non-Error), success with full data,
+ * success with empty arrays, cachedAt present/absent, recentTournaments empty,
+ * winnerFaction present/absent, c.completed > 0 branch, f/p wins singular/plural,
+ * player rank color branches (i===0, i===1, i>=2), player factions filter branch.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { get: vi.fn() },
+}));
+
+import { httpClient } from "@/core/api/httpClient";
+import StatisticsPage from "@/features/statistics/components/StatisticsPage";
+
+const mockGet = vi.mocked(httpClient.get);
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <StatisticsPage />
+    </ChakraProvider>,
+  );
+}
+
+const fullStats = {
+  cachedAt: "2026-06-14T10:00:00Z",
+  tournaments: { pending: 1, active: 2, completed: 5, total: 8 },
+  matches: { pending: 3, in_progress: 1, completed: 20, disputed: 0, total: 24, completionRate: 0.83 },
+  topFactions: [
+    { faction: "Empire", wins: 5 },
+    { faction: "Dwarfs", wins: 3 },
+    { faction: "Greenskins", wins: 1 },
+  ],
+  topPlayers: [
+    { name: "PlayerOne", wins: 7, factions: ["Empire", "Dwarfs"] },
+    { name: "PlayerTwo", wins: 4, factions: [] },
+    { name: "PlayerThree", wins: 2, factions: ["Greenskins"] },
+  ],
+  topCreators: [
+    { username: "Creator1", tournamentsCreated: 10, completed: 5 },
+    { username: "Creator2", tournamentsCreated: 3, completed: 0 },
+  ],
+  recentWinners: [
+    { tournamentName: "Grand Cup", tournamentType: "Single Elimination", winnerName: "Hero1", winnerFaction: "Empire", completedAt: "2026-06-13T00:00:00Z" },
+    { tournamentName: "Minor Cup", tournamentType: "Round Robin", winnerName: "Hero2", winnerFaction: "", completedAt: "2026-06-12T00:00:00Z" },
+  ],
+  recentTournaments: [
+    { _id: "t1", name: "Past Cup", tournamentType: "Swiss System", participants: [{ name: "A", faction: "Empire" }], playerCount: 8, createdAt: "2026-06-10T00:00:00Z" },
+  ],
+};
+
+describe("StatisticsPage – loading state", () => {
+  beforeEach(() => mockGet.mockReset());
+
+  it("shows spinner while loading", async () => {
+    // Deferred promise: keeps component in loading state until we resolve it
+    let resolveGet!: (v: unknown) => void;
+    mockGet.mockImplementationOnce(
+      () => new Promise((r) => { resolveGet = r; }),
+    );
+    renderPage();
+    // Component renders with loading=true initially
+    expect(screen.getByText(/loading statistics/i)).toBeInTheDocument();
+    // Resolve so the promise doesn't hang the test runner
+    await act(async () => {
+      resolveGet({ success: true, data: { ...fullStats, topFactions: [], topPlayers: [], topCreators: [], recentWinners: [], recentTournaments: [] } });
+    });
+  });
+});
+
+describe("StatisticsPage – error states", () => {
+  beforeEach(() => mockGet.mockReset());
+
+  it("shows error message when API throws an Error instance", async () => {
+    mockGet.mockRejectedValueOnce(new Error("Network failure"));
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Network failure")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows generic message when API throws a non-Error", async () => {
+    mockGet.mockRejectedValueOnce("string error");
+    renderPage();
+    await waitFor(() =>
+      expect(
+        screen.getByText("Failed to load statistics"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'No data available' when API returns null data (stats is null)", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: null });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("No data available.")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("StatisticsPage – success with full data", () => {
+  beforeEach(() => mockGet.mockReset());
+
+  it("renders tournament total count", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("8")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows cachedAt time when present", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/updated/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows top faction names", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() => {
+      // "Empire" appears both as a faction card and inside the player faction list;
+      // at least one instance should be present
+      expect(screen.getAllByText("Empire").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows plural 'wins' for faction with multiple wins", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() => {
+      const allWins = screen.getAllByText(/\d+ wins?/);
+      const plural = allWins.find((el) => el.textContent?.includes("5 wins"));
+      expect(plural).toBeTruthy();
+    });
+  });
+
+  it("shows singular 'win' for faction with exactly 1 win", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() => {
+      const singular = screen.getAllByText(/1 win$/).filter((el) => el.textContent === "1 win");
+      expect(singular.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows top player names", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("PlayerOne")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows player faction list when factions are non-empty", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Empire, Dwarfs")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows recent winner tournament name", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Grand Cup")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows top creators with completed badge when completed > 0", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("5 done")).toBeInTheDocument(),
+    );
+  });
+
+  it("does not show 'done' badge for creator with completed = 0", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Creator2")).toBeInTheDocument(),
+    );
+    // Creator2 has completed=0, so no "done" badge with count 0
+    const doneBadges = screen.queryAllByText(/0 done/);
+    expect(doneBadges).toHaveLength(0);
+  });
+
+  it("shows recent completed tournaments section when recentTournaments is non-empty", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: fullStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Past Cup")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("StatisticsPage – empty arrays", () => {
+  beforeEach(() => mockGet.mockReset());
+
+  const emptyStats = {
+    ...fullStats,
+    topFactions: [],
+    topPlayers: [],
+    topCreators: [],
+    recentWinners: [],
+    recentTournaments: [],
+    cachedAt: undefined,
+  };
+
+  it("shows 'No faction data yet' when topFactions is empty", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: emptyStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("No faction data yet.")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'No player data yet' when topPlayers is empty", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: emptyStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("No player data yet.")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'No data yet' when topCreators is empty", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: emptyStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("No data yet.")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows no-recent-winners message when recentWinners is empty", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: emptyStats });
+    renderPage();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/no tournaments completed in the last 7 days/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("does not render 'Recent Completed Tournaments' section when recentTournaments is empty", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: emptyStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.queryByText("Past Cup")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("does not show cachedAt when absent", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: emptyStats });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.queryByText(/updated/i)).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/client-app/src/tests/shared/utils/displayName.test.ts
+++ b/client-app/src/tests/shared/utils/displayName.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Full branch coverage for displayName utility (src/shared/utils/displayName.ts):
+ * - Line 4: `!name` → returns "Unknown"
+ * - Line 5: DELETED_PATTERN matches → returns "Deleted User"
+ * - Line 6: normal name → returns name as-is
+ */
+import { describe, it, expect } from "vitest";
+import { displayName } from "@/shared/utils/displayName";
+
+describe("displayName", () => {
+  it("returns 'Unknown' when name is null", () => {
+    expect(displayName(null)).toBe("Unknown");
+  });
+
+  it("returns 'Unknown' when name is undefined", () => {
+    expect(displayName(undefined)).toBe("Unknown");
+  });
+
+  it("returns 'Unknown' when name is empty string", () => {
+    expect(displayName("")).toBe("Unknown");
+  });
+
+  it("returns 'Deleted User' for deleted_ pattern", () => {
+    expect(displayName("deleted_a1b2c3d4")).toBe("Deleted User");
+  });
+
+  it("returns 'Deleted User' for deleted_ pattern with uppercase", () => {
+    expect(displayName("DELETED_A1B2C3D4")).toBe("Deleted User");
+  });
+
+  it("returns name unchanged for a normal player name", () => {
+    expect(displayName("Karl Franz")).toBe("Karl Franz");
+  });
+
+  it("returns name unchanged for a guest identifier", () => {
+    expect(displayName("guest_abc123")).toBe("guest_abc123");
+  });
+});


### PR DESCRIPTION
## Summary

Fifth batch of branch-coverage tests targeting 5 previously uncovered areas:

- **`displayName.test.ts`** — 100% branch coverage of `src/shared/utils/displayName.ts`: null/undefined/empty → "Unknown", `deleted_` pattern → "Deleted User", normal name pass-through
- **`StatisticsPage.test.tsx`** — loading state, Error vs non-Error catch branch, null `data` response ("No data available."), empty arrays for all leaderboard sections, `cachedAt` present/absent, `completed > 0` badge branch, `winnerFaction` truthy/falsy, `recentTournaments.length > 0` section visibility, faction/player win singular/plural
- **`TournamentsPageHashFalseBranch.test.tsx`** — `handleHashChange` line 143 `else if` false branch: invalid hash fires while `activeTab` is already `tabs[0]`, so condition `activeTab !== tabs[0].id` is false and no state update occurs
- **`CreateTournamentFormCountAndDesc.test.tsx`** — line 121 `parseInt(value) || 2` NaN fallback (empty string and non-numeric value); line 248 `description.length >= 2000` true branch (counter at max chars)
- **`TournamentBrowserUserIdCoverage.test.tsx`** — line 113 `if (p.userId)` true branch (participant matched by userId); line 111 `user.username || uid` false branch (no username → use uid as name)

## Test plan

- [x] All 37 new tests pass locally (`npx vitest run` across all 5 files)
- [x] No source file modifications required — pure test additions
- [x] Does not conflict with batch 2 (PR #149) or batch 3 (PR #150) test files

https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm)_