### PR TITLE
test: batch 5 branch coverage — accountApi, UsernameUpdateForm, LogoutButton, UserStatsCard, TournamentBrowser error

### DIFF
--- a/client-app/src/tests/features/TournamentBrowserErrorBranch.test.tsx
+++ b/client-app/src/tests/features/TournamentBrowserErrorBranch.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Branch coverage for TournamentBrowser.tsx:
+ * - Line 88-90: `Array.isArray(statusFilter) ? statusFilter.join(",") : statusFilter`
+ *   → true branch: statusFilter is an array (used in TournamentsPage for pending+active)
+ * - Line 97: `err instanceof Error ? err.message : "Failed to load tournaments"`
+ *   → false branch: error is not an Error instance → shows "Failed to load tournaments"
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+import TournamentBrowser from "@/features/tournaments/components/TournamentBrowser";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { get: vi.fn() },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: vi.fn(() => ({
+    user: {
+      id: "u1",
+      email: "test@test.com",
+      username: "TestUser",
+      isAuthenticated: true,
+      isGuest: false,
+    },
+    isAuthenticated: vi.fn().mockReturnValue(true),
+  })),
+}));
+
+import { httpClient } from "@/core/api/httpClient";
+
+const mockGet = vi.mocked(httpClient.get);
+
+function renderBrowser(statusFilter: "pending" | "active" | "completed" | ("pending" | "active" | "completed")[]) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <MemoryRouter>
+        <TournamentBrowser
+          statusFilter={statusFilter}
+          emptyMessage="No tournaments."
+        />
+      </MemoryRouter>
+    </ChakraProvider>,
+  );
+}
+
+describe("TournamentBrowser – array statusFilter (line 88-90 true branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("joins array statusFilter with comma in API request URL", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: [] });
+
+    renderBrowser(["pending", "active"]);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining("pending,active"),
+      );
+    });
+  });
+
+  it("renders empty message when statusFilter is array and no tournaments found", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: [] });
+
+    renderBrowser(["pending", "active"]);
+
+    await waitFor(() =>
+      expect(screen.getByText("No tournaments.")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("TournamentBrowser – non-Error catch (line 97 false branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows generic 'Failed to load tournaments' when non-Error is thrown", async () => {
+    mockGet.mockRejectedValueOnce("plain string error");
+
+    renderBrowser("active");
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Failed to load tournaments"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows error.message when Error instance is thrown (true branch for comparison)", async () => {
+    mockGet.mockRejectedValueOnce(new Error("API is down"));
+
+    renderBrowser("active");
+
+    await waitFor(() =>
+      expect(screen.getByText("API is down")).toBeInTheDocument(),
+    );
+  });
+});

--- a/client-app/src/tests/features/account/LogoutButton.test.tsx
+++ b/client-app/src/tests/features/account/LogoutButton.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Branch coverage for LogoutButton.tsx:
+ * - try path: logoutUser() resolves → navigate("/") called
+ * - catch path: logoutUser() throws → console.error called, no navigate
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/features/authentication/api/authenticationApi", () => ({
+  logoutUser: vi.fn(),
+}));
+
+import { logoutUser } from "@/features/authentication/api/authenticationApi";
+import LogoutButton from "@/features/account/components/LogoutButton";
+
+const mockLogoutUser = vi.mocked(logoutUser);
+
+function renderButton() {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <LogoutButton />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("LogoutButton – success path (try branch)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("navigates to / after successful logout", async () => {
+    mockLogoutUser.mockResolvedValueOnce({ success: true, message: "ok" });
+
+    renderButton();
+    await userEvent.click(screen.getByRole("button", { name: /logout/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/");
+    });
+  });
+});
+
+describe("LogoutButton – error path (catch branch)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("logs error and does not navigate when logoutUser throws", async () => {
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mockLogoutUser.mockRejectedValueOnce(new Error("Server error"));
+
+    renderButton();
+    await userEvent.click(screen.getByRole("button", { name: /logout/i }));
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Logout failed:",
+        expect.any(Error),
+      );
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});

--- a/client-app/src/tests/features/account/UserStatsCard.test.tsx
+++ b/client-app/src/tests/features/account/UserStatsCard.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Branch coverage for UserStatsCard.tsx:
+ * - loading=true → shows skeleton / loading state (initial render)
+ * - loading=false, stats=null → shows 0 values, no faction section, no activity message
+ *   (because factions.length is 0 AND tournamentsCreated=0, matchesPlayed=0)
+ * - loading=false, stats with factions → shows faction section; f.count===1 → "match"; f.count>1 → "matches"
+ * - loading=false, matchesPlayed=0 AND tournamentsCreated=0 → shows "No activity" message (line 126-133)
+ * - loading=false, stats with activity → no "No activity" message
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  fetchUserStats: vi.fn(),
+}));
+
+import { fetchUserStats } from "@/features/account/api/accountApi";
+import UserStatsCard from "@/features/account/components/UserStatsCard";
+
+const mockFetchUserStats = vi.mocked(fetchUserStats);
+
+function renderCard() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <UserStatsCard />
+    </ChakraProvider>,
+  );
+}
+
+describe("UserStatsCard – null stats (fetchUserStats returns null)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders 0 values when stats is null", async () => {
+    mockFetchUserStats.mockResolvedValueOnce(null);
+    renderCard();
+
+    await waitFor(() => {
+      // Value is ?? 0 so should show "0" for all stats
+      const zeros = screen.getAllByText("0");
+      expect(zeros.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("does not show faction section when stats is null", async () => {
+    mockFetchUserStats.mockResolvedValueOnce(null);
+    renderCard();
+
+    await waitFor(() => {
+      // Faction section only shows when loading OR factions.length > 0
+      // With null stats, neither condition is true
+      expect(screen.queryByText(/factions played/i)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("UserStatsCard – no activity message (line 126-133)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows no-activity message when matchesPlayed=0 and tournamentsCreated=0", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 0,
+      matchesPlayed: 0,
+      wins: 0,
+      losses: 0,
+      factions: [],
+    });
+    renderCard();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/no activity recorded yet/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("does not show no-activity message when there is activity", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 2,
+      matchesPlayed: 5,
+      wins: 3,
+      losses: 2,
+      factions: [{ name: "Empire", count: 3 }],
+    });
+    renderCard();
+
+    await waitFor(() =>
+      expect(screen.queryByText(/no activity recorded yet/i)).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("UserStatsCard – faction count singular/plural (line 118)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows 'match' (singular) when faction count is 1", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 1,
+      matchesPlayed: 1,
+      wins: 1,
+      losses: 0,
+      factions: [{ name: "Empire", count: 1 }],
+    });
+    renderCard();
+
+    await waitFor(() =>
+      expect(screen.getByText("1 match")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'matches' (plural) when faction count is >1", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 1,
+      matchesPlayed: 5,
+      wins: 3,
+      losses: 2,
+      factions: [{ name: "Dwarfs", count: 5 }],
+    });
+    renderCard();
+
+    await waitFor(() =>
+      expect(screen.getByText("5 matches")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows faction section heading when factions are present", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 1,
+      matchesPlayed: 3,
+      wins: 2,
+      losses: 1,
+      factions: [{ name: "Empire", count: 2 }, { name: "Dwarfs", count: 1 }],
+    });
+    renderCard();
+
+    await waitFor(() =>
+      expect(screen.getByText(/factions played/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/client-app/src/tests/features/account/UsernameUpdateForm.test.tsx
+++ b/client-app/src/tests/features/account/UsernameUpdateForm.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Branch coverage for UsernameUpdateForm.tsx:
+ * - Line 21: `if (error) setError("")` — clears error on re-type when error exists
+ * - Line 27: `!username || username.length < 3` — validation failure
+ * - Line 33: `if (isGuest)` — true (guest) → updateGuestUsername; false → updateAuthUsername
+ * - Line 40: `if (error instanceof Error)` — true: uses error.message; false: generic message
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+vi.mock("@/features/authentication/api/guestApi", () => ({
+  updateGuestUsername: vi.fn(),
+}));
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  updateUsername: vi.fn(),
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: vi.fn((selector: (state: { user: { username: string } }) => unknown) =>
+    selector({ user: { username: "TestUser" } }),
+  ),
+}));
+
+import { updateGuestUsername } from "@/features/authentication/api/guestApi";
+import { updateUsername } from "@/features/account/api/accountApi";
+import UsernameUpdateForm from "@/features/account/components/UsernameUpdateForm";
+
+const mockUpdateGuestUsername = vi.mocked(updateGuestUsername);
+const mockUpdateUsername = vi.mocked(updateUsername);
+
+function renderForm(isGuest = false) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <UsernameUpdateForm isGuest={isGuest} />
+    </ChakraProvider>,
+  );
+}
+
+describe("UsernameUpdateForm – validation branch (line 27)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows validation error when username is empty", async () => {
+    renderForm();
+    const input = screen.getByPlaceholderText(/enter your new username/i);
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/at least 3 characters/i),
+      ).toBeInTheDocument(),
+    );
+    expect(mockUpdateGuestUsername).not.toHaveBeenCalled();
+  });
+
+  it("shows validation error when username is fewer than 3 chars", async () => {
+    renderForm();
+    const input = screen.getByPlaceholderText(/enter your new username/i);
+    fireEvent.change(input, { target: { value: "ab" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/at least 3 characters/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("UsernameUpdateForm – error clearing on change (line 21)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clears error when user types after an error is shown", async () => {
+    renderForm();
+    const input = screen.getByPlaceholderText(/enter your new username/i);
+
+    // Trigger validation error
+    fireEvent.change(input, { target: { value: "a" } });
+    fireEvent.submit(input.closest("form")!);
+    await waitFor(() =>
+      expect(screen.getByText(/at least 3 characters/i)).toBeInTheDocument(),
+    );
+
+    // Now type more text → error should be cleared
+    fireEvent.change(input, { target: { value: "ab" } });
+    // The error clearing happens synchronously via setError("") in handleUsernameChange
+    expect(screen.queryByText(/at least 3 characters/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("UsernameUpdateForm – isGuest branch (line 33)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls updateGuestUsername when isGuest=true", async () => {
+    mockUpdateGuestUsername.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "g1", username: "GuestUser", email: "", isGuest: true, expiresAt: Date.now() + 1000 },
+    });
+
+    renderForm(true);
+    const input = screen.getByPlaceholderText(/enter your new username/i);
+    fireEvent.change(input, { target: { value: "GuestUser" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() =>
+      expect(mockUpdateGuestUsername).toHaveBeenCalledWith("GuestUser"),
+    );
+    expect(mockUpdateUsername).not.toHaveBeenCalled();
+  });
+
+  it("calls updateUsername (auth) when isGuest=false", async () => {
+    mockUpdateUsername.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", username: "AuthUser", email: "a@b.com" },
+    });
+
+    renderForm(false);
+    const input = screen.getByPlaceholderText(/enter your new username/i);
+    fireEvent.change(input, { target: { value: "AuthUser" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() =>
+      expect(mockUpdateUsername).toHaveBeenCalledWith("AuthUser"),
+    );
+    expect(mockUpdateGuestUsername).not.toHaveBeenCalled();
+  });
+});
+
+describe("UsernameUpdateForm – error type branch in catch (line 40)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows error.message when catch receives an Error instance (line 40 true)", async () => {
+    mockUpdateUsername.mockRejectedValueOnce(new Error("Name already taken"));
+
+    renderForm(false);
+    const input = screen.getByPlaceholderText(/enter your new username/i);
+    fireEvent.change(input, { target: { value: "TakenName" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText("Name already taken")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows generic message when catch receives non-Error (line 40 false)", async () => {
+    mockUpdateUsername.mockRejectedValueOnce("plain string error");
+
+    renderForm(false);
+    const input = screen.getByPlaceholderText(/enter your new username/i);
+    fireEvent.change(input, { target: { value: "SomeName" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Failed to update username"),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/client-app/src/tests/features/account/accountApi.test.ts
+++ b/client-app/src/tests/features/account/accountApi.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Branch coverage for src/features/account/api/accountApi.ts.
+ *
+ * Covers:
+ * - fetchUserStats: res.success=false → null (false branch of ternary)
+ * - fetchUserStats: catch → null
+ * - updateUsername: responseData.data?.username absent → falls back to `username` param
+ * - updateUsername: non-Error in catch → "An error occurred"
+ * - deleteAccount: success path (clearUser + toaster)
+ * - deleteAccount: responseData.success=false → throws Error
+ * - deleteAccount: non-Error in catch → "An error occurred"
+ * - updatePassword: success path (toaster)
+ * - updatePassword: responseData.success=false → throws Error
+ * - updatePassword: non-Error in catch → "An error occurred"
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: {
+    getState: vi.fn(() => ({
+      setUser: vi.fn(),
+      clearUser: vi.fn(),
+    })),
+  },
+}));
+
+import { httpClient } from "@/core/api/httpClient";
+import { toaster } from "@/shared/ui/Toaster";
+import { useUserStore } from "@/shared/stores/userStore";
+import {
+  fetchUserStats,
+  updateUsername,
+  deleteAccount,
+  updatePassword,
+} from "@/features/account/api/accountApi";
+
+const mockGet = vi.mocked(httpClient.get);
+const mockPost = vi.mocked(httpClient.post);
+const mockDelete = vi.mocked(httpClient.delete);
+const mockToasterCreate = vi.mocked(toaster.create);
+const mockGetState = vi.mocked(useUserStore.getState);
+
+describe("accountApi – fetchUserStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetState.mockReturnValue({ setUser: vi.fn(), clearUser: vi.fn() } as ReturnType<typeof useUserStore.getState>);
+  });
+
+  it("returns res.data when res.success is true", async () => {
+    const statsData = { tournamentsCreated: 3, matchesPlayed: 10, wins: 5, losses: 5, factions: [] };
+    mockGet.mockResolvedValueOnce({ success: true, data: statsData });
+    const result = await fetchUserStats();
+    expect(result).toEqual(statsData);
+  });
+
+  it("returns null when res.success is false (false branch of ternary)", async () => {
+    mockGet.mockResolvedValueOnce({ success: false, data: null });
+    const result = await fetchUserStats();
+    expect(result).toBeNull();
+  });
+
+  it("returns null on error (catch branch)", async () => {
+    mockGet.mockRejectedValueOnce(new Error("Network error"));
+    const result = await fetchUserStats();
+    expect(result).toBeNull();
+  });
+});
+
+describe("accountApi – updateUsername", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const mockSetUser = vi.fn();
+    mockGetState.mockReturnValue({ setUser: mockSetUser, clearUser: vi.fn() } as ReturnType<typeof useUserStore.getState>);
+  });
+
+  it("uses responseData.data.username when present", async () => {
+    const mockSetUser = vi.fn();
+    mockGetState.mockReturnValue({ setUser: mockSetUser, clearUser: vi.fn() } as ReturnType<typeof useUserStore.getState>);
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", username: "NewName", email: "x@x.com" },
+    });
+
+    await updateUsername("FallbackName");
+
+    expect(mockSetUser).toHaveBeenCalledWith({ username: "NewName" });
+  });
+
+  it("falls back to username param when responseData.data is absent", async () => {
+    const mockSetUser = vi.fn();
+    mockGetState.mockReturnValue({ setUser: mockSetUser, clearUser: vi.fn() } as ReturnType<typeof useUserStore.getState>);
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      // no data property → responseData.data?.username is undefined → || username
+    });
+
+    await updateUsername("FallbackName");
+
+    expect(mockSetUser).toHaveBeenCalledWith({ username: "FallbackName" });
+  });
+
+  it("throws and shows error toaster on failure (success=false)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "Username taken" });
+
+    await expect(updateUsername("TakenName")).rejects.toThrow("Username taken");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
+  });
+
+  it("shows generic error message when non-Error is thrown (catch non-Error branch)", async () => {
+    mockPost.mockRejectedValueOnce("string-error");
+
+    await expect(updateUsername("AnyName")).rejects.toBe("string-error");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "An error occurred",
+        type: "error",
+      }),
+    );
+  });
+});
+
+describe("accountApi – deleteAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetState.mockReturnValue({ setUser: vi.fn(), clearUser: vi.fn() } as ReturnType<typeof useUserStore.getState>);
+  });
+
+  it("calls clearUser and shows success toaster on success", async () => {
+    const mockClearUser = vi.fn();
+    mockGetState.mockReturnValue({ setUser: vi.fn(), clearUser: mockClearUser } as ReturnType<typeof useUserStore.getState>);
+    mockDelete.mockResolvedValueOnce({ success: true, message: "deleted" });
+
+    await deleteAccount();
+
+    expect(mockClearUser).toHaveBeenCalled();
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Account Deleted", type: "success" }),
+    );
+  });
+
+  it("throws when responseData.success is false", async () => {
+    mockDelete.mockResolvedValueOnce({ success: false, message: "Cannot delete" });
+
+    await expect(deleteAccount()).rejects.toThrow("Cannot delete");
+  });
+
+  it("shows generic error when non-Error is thrown (catch non-Error branch)", async () => {
+    mockDelete.mockRejectedValueOnce("raw-error");
+
+    await expect(deleteAccount()).rejects.toBe("raw-error");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "An error occurred",
+        type: "error",
+      }),
+    );
+  });
+});
+
+describe("accountApi – updatePassword", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetState.mockReturnValue({ setUser: vi.fn(), clearUser: vi.fn() } as ReturnType<typeof useUserStore.getState>);
+  });
+
+  const passwordData = {
+    currentPassword: "old123",
+    newPassword: "new123",
+    confirmPassword: "new123",
+  };
+
+  it("shows success toaster when password update succeeds", async () => {
+    mockPost.mockResolvedValueOnce({ success: true, message: "ok" });
+
+    await updatePassword(passwordData);
+
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Password Updated", type: "success" }),
+    );
+  });
+
+  it("throws when responseData.success is false", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "Wrong password" });
+
+    await expect(updatePassword(passwordData)).rejects.toThrow("Wrong password");
+  });
+
+  it("shows generic error when non-Error is thrown (catch non-Error branch)", async () => {
+    mockPost.mockRejectedValueOnce(42);
+
+    await expect(updatePassword(passwordData)).rejects.toBe(42);
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "An error occurred",
+        type: "error",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Sixth batch of branch-coverage tests targeting 5 previously uncovered areas:

- **`accountApi.test.ts`** — `fetchUserStats` false/null branches; `updateUsername` `data?.username || username` fallback + non-Error catch; `deleteAccount` success/failure/non-Error; `updatePassword` success/failure/non-Error (13 tests)
- **`UsernameUpdateForm.test.tsx`** — validation < 3 chars, error clearing on re-type, `isGuest` routing to `updateGuestUsername` vs `updateAuthUsername`, Error vs non-Error in catch (7 tests)
- **`LogoutButton.test.tsx`** — success path navigates to `/`; catch path logs error without navigating (2 tests)
- **`UserStatsCard.test.tsx`** — null stats (0 values, no faction section), no-activity message branch (`matchesPlayed===0 && tournamentsCreated===0`), faction count singular "match" / plural "matches", faction section heading (7 tests)
- **`TournamentBrowserErrorBranch.test.tsx`** — `Array.isArray(statusFilter)` true branch (array joined in URL); non-Error catch → "Failed to load tournaments" generic message (4 tests)

## Test plan

- [x] All 33 new tests pass locally
- [x] No source file modifications
- [x] Does not conflict with batches 2–4

https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm)_