### PR TITLE
test(batch6): 100% branch coverage for account/auth API modules

### DIFF
--- a/client-app/src/tests/features/account/DeleteAccountSection.test.tsx
+++ b/client-app/src/tests/features/account/DeleteAccountSection.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Branch coverage for DeleteAccountSection.tsx:
+ * - Line 22: `if (!confirming)` → true: shows Delete button only
+ * - confirming=true: shows confirmation UI (after clicking Delete Account)
+ * - handleDelete success: navigate("/") called
+ * - handleDelete catch: setIsLoading(false), no navigate
+ * - Cancel button: sets confirming=false
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("../api/accountApi", () => ({
+  deleteAccount: vi.fn(),
+}));
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  deleteAccount: vi.fn(),
+}));
+
+import { deleteAccount } from "@/features/account/api/accountApi";
+import DeleteAccountSection from "@/features/account/components/DeleteAccountSection";
+
+const mockDeleteAccount = vi.mocked(deleteAccount);
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <DeleteAccountSection />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("DeleteAccountSection – confirming=false (line 22 true branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows only Delete Account button initially", () => {
+    renderSection();
+    expect(
+      screen.getByRole("button", { name: /delete account/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+  });
+
+  it("shows confirmation UI after clicking Delete Account", async () => {
+    renderSection();
+    await userEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /yes, delete my account/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /cancel/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("DeleteAccountSection – cancel (restores !confirming)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("hides confirmation UI when Cancel is clicked", async () => {
+    renderSection();
+    await userEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("DeleteAccountSection – handleDelete success path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("navigates to / after successful deletion", async () => {
+    mockDeleteAccount.mockResolvedValueOnce({ success: true, message: "deleted" });
+    renderSection();
+    await userEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    await userEvent.click(screen.getByRole("button", { name: /yes, delete my account/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/");
+    });
+  });
+});
+
+describe("DeleteAccountSection – handleDelete error path (catch branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("stays on page and does not navigate when deleteAccount throws", async () => {
+    mockDeleteAccount.mockRejectedValueOnce(new Error("Server error"));
+    renderSection();
+    await userEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    await userEvent.click(screen.getByRole("button", { name: /yes, delete my account/i }));
+
+    await waitFor(() => {
+      // After catch, loading is reset but the component stays — no navigate
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client-app/src/tests/features/account/GuestAccountSection.test.tsx
+++ b/client-app/src/tests/features/account/GuestAccountSection.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Branch coverage for GuestAccountSection.tsx:
+ * - Line 31: `user.username || "Guest"` → false (no username) shows "Guest" as the username text
+ * - Line 31: `user.username || "Guest"` → true (username set) shows that username text
+ * Note: the component always renders a "Guest" Badge, so when testing the empty-username
+ * branch we assert that there are exactly 2 "Guest" nodes (username text + badge).
+ * When username is set we assert that username text is shown and no duplicate of it.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const mockUseUserStore = vi.fn();
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: (selector: (s: { user: Record<string, unknown> }) => unknown) =>
+    mockUseUserStore(selector),
+}));
+
+vi.mock("@/features/account/components/UsernameUpdateForm", () => ({
+  default: () => <div data-testid="username-update-form" />,
+}));
+
+import GuestAccountSection from "@/features/account/components/GuestAccountSection";
+
+function renderSection() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <GuestAccountSection />
+    </ChakraProvider>,
+  );
+}
+
+describe("GuestAccountSection – username display (line 31 branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Guest' as username text when user.username is falsy (|| right side)", () => {
+    mockUseUserStore.mockImplementation(
+      (selector: (s: { user: Record<string, unknown> }) => unknown) =>
+        selector({ user: { username: "" } }),
+    );
+    renderSection();
+    // component renders both a username Text and a "Guest" Badge — both show "Guest"
+    const guestNodes = screen.getAllByText("Guest");
+    expect(guestNodes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows the actual username when user.username is set (|| left side)", () => {
+    mockUseUserStore.mockImplementation(
+      (selector: (s: { user: Record<string, unknown> }) => unknown) =>
+        selector({ user: { username: "Grimgork" } }),
+    );
+    renderSection();
+    expect(screen.getByText("Grimgork")).toBeInTheDocument();
+    // Badge still says "Guest"
+    expect(screen.getByText("Guest")).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/account/PasswordUpdateForm.test.tsx
+++ b/client-app/src/tests/features/account/PasswordUpdateForm.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Branch coverage for PasswordUpdateForm.tsx:
+ * - Line 24: `!currentPassword || !newPassword || !confirmPassword` → "All fields required"
+ * - Line 29: `newPassword !== confirmPassword` → "don't match"
+ * - Line 34: `newPassword.length < 8` → "at least 8 characters"
+ * - Line 18: `if (passwordError) setPasswordError("")` → clears on re-type
+ * - Line 49: `if (error instanceof Error)` → uses error.message; else → generic
+ * - Line 47: `window.location.reload()` on success (mocked)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  updatePassword: vi.fn(),
+}));
+
+// Mock PasswordInput as a plain input with the id and value/onChange passed through
+vi.mock("@/shared/ui/PasswordInput", () => ({
+  PasswordInput: ({
+    id,
+    value,
+    onChange,
+    placeholder,
+  }: {
+    id: string;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      id={id}
+      data-testid={id}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+    />
+  ),
+}));
+
+import { updatePassword } from "@/features/account/api/accountApi";
+import PasswordUpdateForm from "@/features/account/components/PasswordUpdateForm";
+
+const mockUpdatePassword = vi.mocked(updatePassword);
+
+function renderForm() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PasswordUpdateForm />
+    </ChakraProvider>,
+  );
+}
+
+function fillPasswords(current: string, newPwd: string, confirm: string) {
+  fireEvent.change(screen.getByTestId("currentPassword"), {
+    target: { id: "currentPassword", value: current },
+  });
+  fireEvent.change(screen.getByTestId("newPassword"), {
+    target: { id: "newPassword", value: newPwd },
+  });
+  fireEvent.change(screen.getByTestId("confirmPassword"), {
+    target: { id: "confirmPassword", value: confirm },
+  });
+}
+
+describe("PasswordUpdateForm – validation branches", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'all fields required' when any password field is empty (line 24)", async () => {
+    renderForm();
+    // Leave all fields empty and submit
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText(/all password fields are required/i)).toBeInTheDocument(),
+    );
+    expect(mockUpdatePassword).not.toHaveBeenCalled();
+  });
+
+  it("shows 'don't match' when new passwords differ (line 29)", async () => {
+    renderForm();
+    fillPasswords("oldpass1", "newpass1", "newpass2");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText(/don't match/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'at least 8 characters' when new password is too short (line 34)", async () => {
+    renderForm();
+    fillPasswords("oldpass1", "short", "short");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("PasswordUpdateForm – error clearing on re-type (line 18)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clears passwordError when user types after an error is shown", async () => {
+    renderForm();
+    // Trigger validation error (empty fields)
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+    await waitFor(() =>
+      expect(screen.getByText(/all password fields are required/i)).toBeInTheDocument(),
+    );
+
+    // Now type in any field → error cleared
+    fireEvent.change(screen.getByTestId("currentPassword"), {
+      target: { id: "currentPassword", value: "x" },
+    });
+    expect(screen.queryByText(/all password fields are required/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("PasswordUpdateForm – catch error type branch (line 49)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock window.location.reload to prevent jsdom error
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload: vi.fn() },
+    });
+  });
+
+  it("shows error.message for Error instance in catch (line 49 true)", async () => {
+    mockUpdatePassword.mockRejectedValueOnce(new Error("Wrong current password"));
+    renderForm();
+    fillPasswords("wrong-old", "newpassword1", "newpassword1");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText("Wrong current password")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows generic message for non-Error in catch (line 49 false)", async () => {
+    mockUpdatePassword.mockRejectedValueOnce("plain error");
+    renderForm();
+    fillPasswords("old-pass", "newpassword1", "newpassword1");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to update password")).toBeInTheDocument(),
+    );
+  });
+
+  it("calls window.location.reload on successful update (line 47)", async () => {
+    mockUpdatePassword.mockResolvedValueOnce({ success: true, message: "ok" });
+    renderForm();
+    fillPasswords("old-pass", "newpassword1", "newpassword1");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(window.location.reload).toHaveBeenCalled(),
+    );
+  });
+});

--- a/client-app/src/tests/features/authentication/authenticationApi.test.ts
+++ b/client-app/src/tests/features/authentication/authenticationApi.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Branch coverage for authenticationApi.ts – logoutUser:
+ * - Success path, response.success=true → clearUser + success toast
+ * - Success path, response.success=false → clearUser only, no success toast
+ * - Catch path → clearUser + warning toast + returns { success: true, message: "Logged out locally" }
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPost, mockClearUser, mockToasterCreate } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockClearUser: vi.fn(),
+  mockToasterCreate: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: mockPost },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: { getState: vi.fn(() => ({ clearUser: mockClearUser })) },
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+vi.mock("@/core/auth/pkceAuthService", () => ({
+  PKCEAuthService: {
+    initiatePKCEFlow: vi.fn().mockResolvedValue({ codeChallenge: "cc", state: "st" }),
+    verifyAuthState: vi.fn().mockReturnValue(true),
+    getAndClearCodeVerifier: vi.fn().mockReturnValue("verifier"),
+  },
+}));
+
+import { logoutUser } from "@/features/authentication/api/authenticationApi";
+
+describe("logoutUser – success path (response.success=true)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls clearUser and shows success toast", async () => {
+    mockPost.mockResolvedValueOnce({ success: true, message: "logged out" });
+    const result = await logoutUser();
+    expect(mockClearUser).toHaveBeenCalled();
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(result).toEqual({ success: true, message: "logged out" });
+  });
+});
+
+describe("logoutUser – success path (response.success=false)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls clearUser but does NOT show success toast when response.success is false", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "nope" });
+    const result = await logoutUser();
+    expect(mockClearUser).toHaveBeenCalled();
+    expect(mockToasterCreate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("logoutUser – catch path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clears user locally and shows warning toast when server throws", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Server down"));
+    const result = await logoutUser();
+    expect(mockClearUser).toHaveBeenCalled();
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" }),
+    );
+    expect(result).toEqual({ success: true, message: "Logged out locally" });
+  });
+});

--- a/client-app/src/tests/features/authentication/guestApi.test.ts
+++ b/client-app/src/tests/features/authentication/guestApi.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Branch coverage for guestApi.ts:
+ * - createGuestUser success with expiresAt (line 28 || left side)
+ * - createGuestUser success WITHOUT expiresAt → fallback 48h (line 28 || right side)
+ * - createGuestUser !success → throws "Failed to create guest user account"
+ * - createGuestUser catch: Error instance → error.message in toast
+ * - createGuestUser catch: non-Error → "An error occurred" in toast
+ * - updateGuestUsername success
+ * - updateGuestUsername !success → throws "Failed to update guest user account"
+ * - updateGuestUsername catch: Error instance
+ * - updateGuestUsername catch: non-Error
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPost, mockSetUser, mockToasterCreate } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockSetUser: vi.fn(),
+  mockToasterCreate: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: mockPost },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: { getState: vi.fn(() => ({ setUser: mockSetUser })) },
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+import { createGuestUser, updateGuestUsername } from "@/features/authentication/api/guestApi";
+
+describe("createGuestUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets user with server-provided expiresAt (line 28 true)", async () => {
+    const futureTime = Date.now() + 1000;
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { id: "u1", username: "g1", email: "", isGuest: true, expiresAt: futureTime },
+    });
+    const result = await createGuestUser();
+    expect(result.success).toBe(true);
+    expect(mockSetUser).toHaveBeenCalledWith(expect.objectContaining({ expiresAt: futureTime }));
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "success" }));
+  });
+
+  it("falls back to 48h default when expiresAt is missing (line 28 false)", async () => {
+    const before = Date.now();
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { id: "u2", username: "g2", email: "", isGuest: true },
+    });
+    await createGuestUser();
+    const callArg = mockSetUser.mock.calls[0][0];
+    expect(callArg.expiresAt).toBeGreaterThanOrEqual(before + 48 * 3600 * 1000 - 100);
+  });
+
+  it("throws when success=false (line 47 else branch)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "no" });
+    await expect(createGuestUser()).rejects.toThrow("Failed to create guest user account");
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+  });
+
+  it("uses error.message in toast for Error instance in catch (line 55 true)", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Network failure"));
+    await expect(createGuestUser()).rejects.toThrow("Network failure");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Network failure", type: "error" }),
+    );
+  });
+
+  it("uses 'An error occurred' for non-Error in catch (line 55 false)", async () => {
+    mockPost.mockRejectedValueOnce("plain string error");
+    await expect(createGuestUser()).rejects.toBe("plain string error");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "An error occurred", type: "error" }),
+    );
+  });
+});
+
+describe("updateGuestUsername", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates user store and shows success toast on success", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { username: "newname" },
+    });
+    const result = await updateGuestUsername("newname");
+    expect(result.success).toBe(true);
+    expect(mockSetUser).toHaveBeenCalledWith({ username: "newname" });
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "success" }));
+  });
+
+  it("throws when success=false (else branch)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "bad" });
+    await expect(updateGuestUsername("x")).rejects.toThrow(
+      "Failed to update guest user account",
+    );
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+  });
+
+  it("uses error.message in toast for Error instance in catch", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Username taken"));
+    await expect(updateGuestUsername("taken")).rejects.toThrow("Username taken");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Username taken", type: "error" }),
+    );
+  });
+
+  it("uses 'An error occurred' for non-Error in catch", async () => {
+    mockPost.mockRejectedValueOnce(42);
+    await expect(updateGuestUsername("x")).rejects.toBe(42);
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "An error occurred", type: "error" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **PasswordUpdateForm**: all validation branches (empty fields, mismatch, too short), error clearing on re-type, `Error` vs non-`Error` catch, `window.location.reload` on success
- **DeleteAccountSection**: `confirming` toggle, cancel restores initial state, success → `navigate("/")`, catch → no navigate
- **GuestAccountSection**: `user.username || "Guest"` — both branches (empty shows "Guest", set shows actual name)
- **guestApi**: `createGuestUser` with/without `expiresAt`, `!success` throw, `Error`/non-`Error` catch; same for `updateGuestUsername`
- **authenticationApi** (`logoutUser`): success toast when `response.success=true`, no toast when `false`, warning toast in catch path

## Test plan

- [x] All 26 tests pass locally: `npx vitest run` across all 5 files
- [x] Uses `vi.hoisted` to avoid factory hoisting issues in pure-API test files
- [x] Mocks `PasswordInput` and `UsernameUpdateForm` as simple controlled inputs to avoid Chakra rendering complexity

https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm)_