### PR TITLE
test(batch9): branch coverage for auth forms, ResetPasswordPage, Terms/Privacy pages

### DIFF
--- a/client-app/src/tests/features/account/AccountPage.test.tsx
+++ b/client-app/src/tests/features/account/AccountPage.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Branch coverage for AccountPage.tsx:
+ * - user.isAuthenticated=false → setIsValidatingSession(false) immediately, shows UnauthenticatedSection
+ * - user.isAuthenticated=true, refreshSession resolves valid=true, isGuest=true → GuestAccountSection
+ * - user.isAuthenticated=true, isGuest=false, valid=true → AuthenticatedAccountSection
+ * - user.isAuthenticated=true, valid=false → navigate("/auth"), clearUser, warning toast, UnauthenticatedSection
+ * - user.isAuthenticated=true, refreshSession rejects → setSessionValid(false), UnauthenticatedSection
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const {
+  mockNavigate,
+  mockClearUser,
+  mockToasterCreate,
+  mockRefreshSession,
+  mockUseUserStore,
+} = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockClearUser: vi.fn(),
+  mockToasterCreate: vi.fn(),
+  mockRefreshSession: vi.fn(),
+  mockUseUserStore: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: (selector: (s: { user: Record<string, unknown>; clearUser: () => void }) => unknown) =>
+    mockUseUserStore(selector),
+}));
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  refreshSession: mockRefreshSession,
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+vi.mock("@/features/account/components/GuestAccountSection", () => ({
+  default: () => <div data-testid="guest-section" />,
+}));
+vi.mock("@/features/account/components/AuthenticatedAccountSection", () => ({
+  default: () => <div data-testid="auth-section" />,
+}));
+vi.mock("@/features/account/components/UnauthenticatedSection", () => ({
+  default: () => <div data-testid="unauth-section" />,
+}));
+
+import AccountPage from "@/features/account/components/AccountPage";
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+  return {
+    isAuthenticated: false,
+    isGuest: false,
+    username: "",
+    email: "",
+    id: "",
+    ...overrides,
+  };
+}
+
+function renderPage(user: Record<string, unknown>) {
+  mockUseUserStore.mockImplementation(
+    (selector: (s: { user: Record<string, unknown>; clearUser: () => void }) => unknown) =>
+      selector({ user, clearUser: mockClearUser }),
+  );
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <AccountPage />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("AccountPage – unauthenticated (else branch, no refreshSession)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows UnauthenticatedSection immediately when not authenticated", async () => {
+    renderPage(makeUser());
+    await waitFor(() =>
+      expect(screen.getByTestId("unauth-section")).toBeInTheDocument(),
+    );
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("AccountPage – authenticated guest, session valid", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows GuestAccountSection after refresh resolves valid=true", async () => {
+    mockRefreshSession.mockResolvedValueOnce(true);
+    renderPage(makeUser({ isAuthenticated: true, isGuest: true }));
+    await waitFor(() =>
+      expect(screen.getByTestId("guest-section")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("AccountPage – authenticated registered user, session valid", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows AuthenticatedAccountSection when authenticated + not guest + valid", async () => {
+    mockRefreshSession.mockResolvedValueOnce(true);
+    renderPage(makeUser({ isAuthenticated: true, isGuest: false }));
+    await waitFor(() =>
+      expect(screen.getByTestId("auth-section")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("AccountPage – authenticated, session invalid (valid=false branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls clearUser, navigate('/auth'), shows warning toast, then UnauthenticatedSection", async () => {
+    mockRefreshSession.mockResolvedValueOnce(false);
+    renderPage(makeUser({ isAuthenticated: true, isGuest: false }));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/auth"));
+    expect(mockClearUser).toHaveBeenCalled();
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" }),
+    );
+  });
+});
+
+describe("AccountPage – refreshSession rejects (catch branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows UnauthenticatedSection when refreshSession throws", async () => {
+    mockRefreshSession.mockRejectedValueOnce(new Error("network"));
+    renderPage(makeUser({ isAuthenticated: true, isGuest: false }));
+    await waitFor(() =>
+      expect(screen.getByTestId("unauth-section")).toBeInTheDocument(),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/client-app/src/tests/features/account/AuthenticatedAccountSection.test.tsx
+++ b/client-app/src/tests/features/account/AuthenticatedAccountSection.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Branch coverage for AuthenticatedAccountSection.tsx:
+ * - Line 37: `user.username || "-"` → shows username when set
+ * - Line 37: `user.username || "-"` → shows "-" when username is empty/falsy
+ * - user.email is rendered
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const mockUseUserStore = vi.fn();
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: (selector: (s: { user: Record<string, unknown> }) => unknown) =>
+    mockUseUserStore(selector),
+}));
+
+// Mock all child components to isolate this component
+vi.mock("@/features/account/components/UsernameUpdateForm", () => ({
+  default: () => <div data-testid="username-form" />,
+}));
+vi.mock("@/features/account/components/PasswordUpdateForm", () => ({
+  default: () => <div data-testid="password-form" />,
+}));
+vi.mock("@/features/account/components/LogoutButton", () => ({
+  default: () => <div data-testid="logout-button" />,
+}));
+vi.mock("@/features/account/components/DeleteAccountSection", () => ({
+  default: () => <div data-testid="delete-section" />,
+}));
+vi.mock("@/features/account/components/UserStatsCard", () => ({
+  default: () => <div data-testid="user-stats-card" />,
+}));
+
+import AuthenticatedAccountSection from "@/features/account/components/AuthenticatedAccountSection";
+
+function renderSection(username = "Grimgork", email = "g@g.com") {
+  mockUseUserStore.mockImplementation(
+    (selector: (s: { user: Record<string, unknown> }) => unknown) =>
+      selector({ user: { username, email } }),
+  );
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <AuthenticatedAccountSection />
+    </ChakraProvider>,
+  );
+}
+
+describe("AuthenticatedAccountSection – username display (line 37 branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows the actual username when user.username is set (|| left side)", () => {
+    renderSection("Grimgork");
+    expect(screen.getByText("Grimgork")).toBeInTheDocument();
+  });
+
+  it("shows '-' when user.username is empty (|| right side)", () => {
+    renderSection("");
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("shows the user email", () => {
+    renderSection("Hero", "hero@warhammer.com");
+    expect(screen.getByText("hero@warhammer.com")).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/account/DeleteAccountSection.test.tsx
+++ b/client-app/src/tests/features/account/DeleteAccountSection.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Branch coverage for DeleteAccountSection.tsx:
+ * - Line 22: `if (!confirming)` → true: shows Delete button only
+ * - confirming=true: shows confirmation UI (after clicking Delete Account)
+ * - handleDelete success: navigate("/") called
+ * - handleDelete catch: setIsLoading(false), no navigate
+ * - Cancel button: sets confirming=false
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("../api/accountApi", () => ({
+  deleteAccount: vi.fn(),
+}));
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  deleteAccount: vi.fn(),
+}));
+
+import { deleteAccount } from "@/features/account/api/accountApi";
+import DeleteAccountSection from "@/features/account/components/DeleteAccountSection";
+
+const mockDeleteAccount = vi.mocked(deleteAccount);
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <DeleteAccountSection />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("DeleteAccountSection – confirming=false (line 22 true branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows only Delete Account button initially", () => {
+    renderSection();
+    expect(
+      screen.getByRole("button", { name: /delete account/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+  });
+
+  it("shows confirmation UI after clicking Delete Account", async () => {
+    renderSection();
+    await userEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /yes, delete my account/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /cancel/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("DeleteAccountSection – cancel (restores !confirming)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("hides confirmation UI when Cancel is clicked", async () => {
+    renderSection();
+    await userEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("DeleteAccountSection – handleDelete success path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("navigates to / after successful deletion", async () => {
+    mockDeleteAccount.mockResolvedValueOnce({ success: true, message: "deleted" });
+    renderSection();
+    await userEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    await userEvent.click(screen.getByRole("button", { name: /yes, delete my account/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/");
+    });
+  });
+});
+
+describe("DeleteAccountSection – handleDelete error path (catch branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("stays on page and does not navigate when deleteAccount throws", async () => {
+    mockDeleteAccount.mockRejectedValueOnce(new Error("Server error"));
+    renderSection();
+    await userEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    await userEvent.click(screen.getByRole("button", { name: /yes, delete my account/i }));
+
+    await waitFor(() => {
+      // After catch, loading is reset but the component stays — no navigate
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client-app/src/tests/features/account/GuestAccountSection.test.tsx
+++ b/client-app/src/tests/features/account/GuestAccountSection.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Branch coverage for GuestAccountSection.tsx:
+ * - Line 31: `user.username || "Guest"` → false (no username) shows "Guest" as the username text
+ * - Line 31: `user.username || "Guest"` → true (username set) shows that username text
+ * Note: the component always renders a "Guest" Badge, so when testing the empty-username
+ * branch we assert that there are exactly 2 "Guest" nodes (username text + badge).
+ * When username is set we assert that username text is shown and no duplicate of it.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const mockUseUserStore = vi.fn();
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: (selector: (s: { user: Record<string, unknown> }) => unknown) =>
+    mockUseUserStore(selector),
+}));
+
+vi.mock("@/features/account/components/UsernameUpdateForm", () => ({
+  default: () => <div data-testid="username-update-form" />,
+}));
+
+import GuestAccountSection from "@/features/account/components/GuestAccountSection";
+
+function renderSection() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <GuestAccountSection />
+    </ChakraProvider>,
+  );
+}
+
+describe("GuestAccountSection – username display (line 31 branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Guest' as username text when user.username is falsy (|| right side)", () => {
+    mockUseUserStore.mockImplementation(
+      (selector: (s: { user: Record<string, unknown> }) => unknown) =>
+        selector({ user: { username: "" } }),
+    );
+    renderSection();
+    // component renders both a username Text and a "Guest" Badge — both show "Guest"
+    const guestNodes = screen.getAllByText("Guest");
+    expect(guestNodes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows the actual username when user.username is set (|| left side)", () => {
+    mockUseUserStore.mockImplementation(
+      (selector: (s: { user: Record<string, unknown> }) => unknown) =>
+        selector({ user: { username: "Grimgork" } }),
+    );
+    renderSection();
+    expect(screen.getByText("Grimgork")).toBeInTheDocument();
+    // Badge still says "Guest"
+    expect(screen.getByText("Guest")).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/account/PasswordUpdateForm.test.tsx
+++ b/client-app/src/tests/features/account/PasswordUpdateForm.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Branch coverage for PasswordUpdateForm.tsx:
+ * - Line 24: `!currentPassword || !newPassword || !confirmPassword` → "All fields required"
+ * - Line 29: `newPassword !== confirmPassword` → "don't match"
+ * - Line 34: `newPassword.length < 8` → "at least 8 characters"
+ * - Line 18: `if (passwordError) setPasswordError("")` → clears on re-type
+ * - Line 49: `if (error instanceof Error)` → uses error.message; else → generic
+ * - Line 47: `window.location.reload()` on success (mocked)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  updatePassword: vi.fn(),
+}));
+
+// Mock PasswordInput as a plain input with the id and value/onChange passed through
+vi.mock("@/shared/ui/PasswordInput", () => ({
+  PasswordInput: ({
+    id,
+    value,
+    onChange,
+    placeholder,
+  }: {
+    id: string;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      id={id}
+      data-testid={id}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+    />
+  ),
+}));
+
+import { updatePassword } from "@/features/account/api/accountApi";
+import PasswordUpdateForm from "@/features/account/components/PasswordUpdateForm";
+
+const mockUpdatePassword = vi.mocked(updatePassword);
+
+function renderForm() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PasswordUpdateForm />
+    </ChakraProvider>,
+  );
+}
+
+function fillPasswords(current: string, newPwd: string, confirm: string) {
+  fireEvent.change(screen.getByTestId("currentPassword"), {
+    target: { id: "currentPassword", value: current },
+  });
+  fireEvent.change(screen.getByTestId("newPassword"), {
+    target: { id: "newPassword", value: newPwd },
+  });
+  fireEvent.change(screen.getByTestId("confirmPassword"), {
+    target: { id: "confirmPassword", value: confirm },
+  });
+}
+
+describe("PasswordUpdateForm – validation branches", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'all fields required' when any password field is empty (line 24)", async () => {
+    renderForm();
+    // Leave all fields empty and submit
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText(/all password fields are required/i)).toBeInTheDocument(),
+    );
+    expect(mockUpdatePassword).not.toHaveBeenCalled();
+  });
+
+  it("shows 'don't match' when new passwords differ (line 29)", async () => {
+    renderForm();
+    fillPasswords("oldpass1", "newpass1", "newpass2");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText(/don't match/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'at least 8 characters' when new password is too short (line 34)", async () => {
+    renderForm();
+    fillPasswords("oldpass1", "short", "short");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("PasswordUpdateForm – error clearing on re-type (line 18)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clears passwordError when user types after an error is shown", async () => {
+    renderForm();
+    // Trigger validation error (empty fields)
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+    await waitFor(() =>
+      expect(screen.getByText(/all password fields are required/i)).toBeInTheDocument(),
+    );
+
+    // Now type in any field → error cleared
+    fireEvent.change(screen.getByTestId("currentPassword"), {
+      target: { id: "currentPassword", value: "x" },
+    });
+    expect(screen.queryByText(/all password fields are required/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("PasswordUpdateForm – catch error type branch (line 49)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock window.location.reload to prevent jsdom error
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload: vi.fn() },
+    });
+  });
+
+  it("shows error.message for Error instance in catch (line 49 true)", async () => {
+    mockUpdatePassword.mockRejectedValueOnce(new Error("Wrong current password"));
+    renderForm();
+    fillPasswords("wrong-old", "newpassword1", "newpassword1");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText("Wrong current password")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows generic message for non-Error in catch (line 49 false)", async () => {
+    mockUpdatePassword.mockRejectedValueOnce("plain error");
+    renderForm();
+    fillPasswords("old-pass", "newpassword1", "newpassword1");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to update password")).toBeInTheDocument(),
+    );
+  });
+
+  it("calls window.location.reload on successful update (line 47)", async () => {
+    mockUpdatePassword.mockResolvedValueOnce({ success: true, message: "ok" });
+    renderForm();
+    fillPasswords("old-pass", "newpassword1", "newpassword1");
+    fireEvent.submit(screen.getByRole("button", { name: /update password/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(window.location.reload).toHaveBeenCalled(),
+    );
+  });
+});

--- a/client-app/src/tests/features/account/UnauthenticatedSection.test.tsx
+++ b/client-app/src/tests/features/account/UnauthenticatedSection.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Branch coverage for UnauthenticatedSection.tsx:
+ * - Renders "Not signed in" heading
+ * - Clicking the button dispatches "auth-event" CustomEvent with detail { type: "open-drawer" }
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import UnauthenticatedSection from "@/features/account/components/UnauthenticatedSection";
+
+function renderSection() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <UnauthenticatedSection />
+    </ChakraProvider>,
+  );
+}
+
+describe("UnauthenticatedSection", () => {
+  it("renders 'Not signed in' heading", () => {
+    renderSection();
+    expect(screen.getByText(/not signed in/i)).toBeInTheDocument();
+  });
+
+  it("dispatches 'auth-event' CustomEvent when Sign in button is clicked", async () => {
+    renderSection();
+    const handler = vi.fn();
+    document.addEventListener("auth-event", handler);
+
+    await userEvent.click(screen.getByRole("button", { name: /sign in \/ register/i }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const evt = handler.mock.calls[0][0] as CustomEvent;
+    expect(evt.detail).toEqual({ type: "open-drawer" });
+
+    document.removeEventListener("auth-event", handler);
+  });
+});

--- a/client-app/src/tests/features/authentication/LogoutButton.test.tsx
+++ b/client-app/src/tests/features/authentication/LogoutButton.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Branch coverage for authentication/components/LogoutButton.tsx:
+ * - handleLogout guard (line 21): isLoggingOutRef.current=true → early return (double-click prevention)
+ * - Success path: logoutUser resolves → navigate("/")
+ * - Catch path: logoutUser rejects → still navigate("/")
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const { mockNavigate, mockLogoutUser } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockLogoutUser: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/features/authentication/api/authenticationApi", () => ({
+  logoutUser: mockLogoutUser,
+}));
+
+import { LogoutButton } from "@/features/authentication/components/LogoutButton";
+
+function renderButton() {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <LogoutButton />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("LogoutButton – success path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("navigates to / after successful logout", async () => {
+    mockLogoutUser.mockResolvedValueOnce({ success: true, message: "ok" });
+    renderButton();
+    await userEvent.click(screen.getByRole("button", { name: /logout/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+});
+
+describe("LogoutButton – catch path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("still navigates to / when logoutUser throws", async () => {
+    mockLogoutUser.mockRejectedValueOnce(new Error("Server error"));
+    renderButton();
+    await userEvent.click(screen.getByRole("button", { name: /logout/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+});
+
+describe("LogoutButton – double-click guard (line 21 true branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ignores second click while logout is in progress", async () => {
+    let resolve!: () => void;
+    mockLogoutUser.mockImplementationOnce(
+      () => new Promise<void>((r) => { resolve = r; }),
+    );
+
+    renderButton();
+    const btn = screen.getByRole("button", { name: /logout/i });
+
+    // First click — starts the in-flight logout
+    await userEvent.click(btn);
+    // Second click should hit the guard and return early
+    await userEvent.click(btn);
+
+    // logoutUser should only be called once
+    expect(mockLogoutUser).toHaveBeenCalledTimes(1);
+
+    // Resolve the in-flight promise so the component can clean up
+    await act(async () => { resolve(); });
+  });
+});

--- a/client-app/src/tests/features/authentication/PasswordResetForm.test.tsx
+++ b/client-app/src/tests/features/authentication/PasswordResetForm.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Branch coverage for authentication/components/PasswordResetForm.tsx:
+ * - onBackClick prop: clicking "Back to Login" calls it
+ * - handlePasswordResetSubmit success: requestPasswordReset resolves → onSuccess called
+ * - handlePasswordResetSubmit catch: requestPasswordReset rejects → onSuccess NOT called
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const { mockRequestPasswordReset } = vi.hoisted(() => ({
+  mockRequestPasswordReset: vi.fn(),
+}));
+
+vi.mock("@/features/authentication/api/passwordResetApi", () => ({
+  requestPasswordReset: mockRequestPasswordReset,
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  Toaster: () => null,
+  toaster: { create: vi.fn() },
+}));
+
+import { PasswordResetForm } from "@/features/authentication/components/PasswordResetForm";
+
+function renderForm(onBackClick = vi.fn(), onSuccess = vi.fn()) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PasswordResetForm onBackClick={onBackClick} onSuccess={onSuccess} />
+    </ChakraProvider>,
+  );
+}
+
+describe("PasswordResetForm – Back to Login button", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls onBackClick when 'Back to Login' is clicked", async () => {
+    const onBackClick = vi.fn();
+    renderForm(onBackClick);
+    await userEvent.click(screen.getByRole("button", { name: /back to login/i }));
+    expect(onBackClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PasswordResetForm – success path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls onSuccess after requestPasswordReset resolves", async () => {
+    mockRequestPasswordReset.mockResolvedValueOnce({ success: true, message: "sent" });
+    const onSuccess = vi.fn();
+    renderForm(vi.fn(), onSuccess);
+
+    fireEvent.change(screen.getByRole("textbox", { name: /email/i }), {
+      target: { value: "hero@warhammer.com" },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /send reset link/i }).closest("form")!);
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(mockRequestPasswordReset).toHaveBeenCalledWith("hero@warhammer.com");
+  });
+});
+
+describe("PasswordResetForm – catch path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does NOT call onSuccess when requestPasswordReset throws", async () => {
+    mockRequestPasswordReset.mockRejectedValueOnce(new Error("Not found"));
+    const onSuccess = vi.fn();
+    renderForm(vi.fn(), onSuccess);
+
+    fireEvent.change(screen.getByRole("textbox", { name: /email/i }), {
+      target: { value: "hero@warhammer.com" },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /send reset link/i }).closest("form")!);
+
+    await waitFor(() =>
+      expect(mockRequestPasswordReset).toHaveBeenCalled(),
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/client-app/src/tests/features/authentication/RegistrationForm.test.tsx
+++ b/client-app/src/tests/features/authentication/RegistrationForm.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Branch coverage for authentication/components/RegistrationForm.tsx:
+ * - onSubmit success: registerUser resolves → navigate("/")
+ * - onSubmit catch: registerUser rejects → no navigate
+ * - Validation: short username → error shown, no registerUser call
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const { mockNavigate, mockRegisterUser } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockRegisterUser: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/features/authentication/api/registrationApi", () => ({
+  registerUser: mockRegisterUser,
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  Toaster: () => null,
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("@/shared/ui/PasswordInput", () => ({
+  PasswordInput: React.forwardRef(
+    (props: React.InputHTMLAttributes<HTMLInputElement>, ref: React.ForwardedRef<HTMLInputElement>) => (
+      <input ref={ref} {...props} />
+    ),
+  ),
+}));
+
+import { RegistrationForm } from "@/features/authentication/components/RegistrationForm";
+
+function fillForm(username = "Grimgork", email = "g@g.com", password = "hunter123") {
+  fireEvent.change(screen.getByRole("textbox", { name: /username/i }), {
+    target: { value: username },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /email/i }), {
+    target: { value: email },
+  });
+  const pwInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+  if (pwInput) fireEvent.change(pwInput, { target: { value: password } });
+}
+
+function renderForm() {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <RegistrationForm />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("RegistrationForm – success path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls registerUser and navigates to / on success", async () => {
+    mockRegisterUser.mockResolvedValueOnce({ success: true });
+    renderForm();
+    fillForm();
+    fireEvent.submit(screen.getByRole("button", { name: /register/i }).closest("form")!);
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/"));
+    expect(mockRegisterUser).toHaveBeenCalledWith(
+      expect.objectContaining({ username: "Grimgork", email: "g@g.com" }),
+    );
+  });
+});
+
+describe("RegistrationForm – catch path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not navigate when registerUser throws", async () => {
+    mockRegisterUser.mockRejectedValueOnce(new Error("Email taken"));
+    renderForm();
+    fillForm();
+    fireEvent.submit(screen.getByRole("button", { name: /register/i }).closest("form")!);
+
+    await waitFor(() => expect(mockRegisterUser).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/client-app/src/tests/features/authentication/ResetPasswordPage.test.tsx
+++ b/client-app/src/tests/features/authentication/ResetPasswordPage.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Branch coverage for authentication/components/ResetPasswordPage.tsx:
+ * - No token in URL (useEffect line 83: !token → invalid state) → "Invalid Reset Link"
+ * - Token present, verifyResetToken → success=false → "Invalid Reset Link"
+ * - Token present, verifyResetToken → success=true + validUntil → shows form with expiry time
+ * - Token present, verifyResetToken → success=true + no validUntil → shows form without expiry
+ * - Token present, verifyResetToken throws → "Invalid Reset Link"
+ * - Loading state (before verifyResetToken resolves): "Verifying Your Reset Link"
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const { mockVerifyResetToken, mockResetPassword, mockNavigate, mockToasterCreate } = vi.hoisted(
+  () => ({
+    mockVerifyResetToken: vi.fn(),
+    mockResetPassword: vi.fn(),
+    mockNavigate: vi.fn(),
+    mockToasterCreate: vi.fn(),
+  }),
+);
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/features/authentication/api/passwordResetApi", () => ({
+  verifyResetToken: mockVerifyResetToken,
+  resetPassword: mockResetPassword,
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+vi.mock("@/shared/ui/PasswordInput", () => ({
+  PasswordInput: React.forwardRef(
+    (props: React.InputHTMLAttributes<HTMLInputElement>, ref: React.ForwardedRef<HTMLInputElement>) => (
+      <input ref={ref} {...props} />
+    ),
+  ),
+}));
+
+import ResetPasswordPage from "@/features/authentication/components/ResetPasswordPage";
+
+function renderPage(search = "") {
+  // Set window.location.search for the component's useEffect
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, search },
+  });
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <ResetPasswordPage />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("ResetPasswordPage – no token in URL (line 83 !token branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Invalid Reset Link' when no token query param", async () => {
+    renderPage("");
+    await waitFor(() =>
+      expect(screen.getByText(/invalid reset link/i)).toBeInTheDocument(),
+    );
+    expect(mockVerifyResetToken).not.toHaveBeenCalled();
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
+  });
+});
+
+describe("ResetPasswordPage – loading state", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Verifying Your Reset Link' while verifyResetToken is in flight", () => {
+    mockVerifyResetToken.mockReturnValueOnce(new Promise(() => {}));
+    renderPage("?token=abc123");
+    expect(screen.getByText(/verifying your reset link/i)).toBeInTheDocument();
+  });
+});
+
+describe("ResetPasswordPage – token invalid (verifyResetToken success=false)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Invalid Reset Link' when token is rejected (success=false)", async () => {
+    mockVerifyResetToken.mockResolvedValueOnce({ success: false });
+    renderPage("?token=badtoken");
+    await waitFor(() =>
+      expect(screen.getByText(/invalid reset link/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("ResetPasswordPage – token valid with validUntil (expiryTime branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows form and expiry time when token is valid with validUntil", async () => {
+    const validUntil = Date.now() + 60 * 60 * 1000;
+    mockVerifyResetToken.mockResolvedValueOnce({
+      success: true,
+      data: { userId: "u1", validUntil },
+    });
+    renderPage("?token=goodtoken");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /reset password/i })).toBeInTheDocument(),
+    );
+    // expiry time is shown (toLocaleTimeString returns something)
+    expect(screen.getByText(/this link will expire at/i)).toBeInTheDocument();
+  });
+});
+
+describe("ResetPasswordPage – token valid without validUntil (no expiryTime)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows form without expiry text when validUntil is absent", async () => {
+    mockVerifyResetToken.mockResolvedValueOnce({ success: true, data: {} });
+    renderPage("?token=goodtoken2");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /reset password/i })).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/this link will expire at/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("ResetPasswordPage – verifyResetToken throws (catch branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Invalid Reset Link' when verifyResetToken rejects", async () => {
+    mockVerifyResetToken.mockRejectedValueOnce(new Error("Network error"));
+    renderPage("?token=errtoken");
+    await waitFor(() =>
+      expect(screen.getByText(/invalid reset link/i)).toBeInTheDocument(),
+    );
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
+  });
+});

--- a/client-app/src/tests/features/authentication/authenticationApi.test.ts
+++ b/client-app/src/tests/features/authentication/authenticationApi.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Branch coverage for authenticationApi.ts – logoutUser:
+ * - Success path, response.success=true → clearUser + success toast
+ * - Success path, response.success=false → clearUser only, no success toast
+ * - Catch path → clearUser + warning toast + returns { success: true, message: "Logged out locally" }
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPost, mockClearUser, mockToasterCreate } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockClearUser: vi.fn(),
+  mockToasterCreate: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: mockPost },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: { getState: vi.fn(() => ({ clearUser: mockClearUser })) },
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+vi.mock("@/core/auth/pkceAuthService", () => ({
+  PKCEAuthService: {
+    initiatePKCEFlow: vi.fn().mockResolvedValue({ codeChallenge: "cc", state: "st" }),
+    verifyAuthState: vi.fn().mockReturnValue(true),
+    getAndClearCodeVerifier: vi.fn().mockReturnValue("verifier"),
+  },
+}));
+
+import { logoutUser } from "@/features/authentication/api/authenticationApi";
+
+describe("logoutUser – success path (response.success=true)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls clearUser and shows success toast", async () => {
+    mockPost.mockResolvedValueOnce({ success: true, message: "logged out" });
+    const result = await logoutUser();
+    expect(mockClearUser).toHaveBeenCalled();
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(result).toEqual({ success: true, message: "logged out" });
+  });
+});
+
+describe("logoutUser – success path (response.success=false)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls clearUser but does NOT show success toast when response.success is false", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "nope" });
+    const result = await logoutUser();
+    expect(mockClearUser).toHaveBeenCalled();
+    expect(mockToasterCreate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("logoutUser – catch path", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clears user locally and shows warning toast when server throws", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Server down"));
+    const result = await logoutUser();
+    expect(mockClearUser).toHaveBeenCalled();
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" }),
+    );
+    expect(result).toEqual({ success: true, message: "Logged out locally" });
+  });
+});

--- a/client-app/src/tests/features/authentication/guestApi.test.ts
+++ b/client-app/src/tests/features/authentication/guestApi.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Branch coverage for guestApi.ts:
+ * - createGuestUser success with expiresAt (line 28 || left side)
+ * - createGuestUser success WITHOUT expiresAt → fallback 48h (line 28 || right side)
+ * - createGuestUser !success → throws "Failed to create guest user account"
+ * - createGuestUser catch: Error instance → error.message in toast
+ * - createGuestUser catch: non-Error → "An error occurred" in toast
+ * - updateGuestUsername success
+ * - updateGuestUsername !success → throws "Failed to update guest user account"
+ * - updateGuestUsername catch: Error instance
+ * - updateGuestUsername catch: non-Error
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPost, mockSetUser, mockToasterCreate } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockSetUser: vi.fn(),
+  mockToasterCreate: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: mockPost },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: { getState: vi.fn(() => ({ setUser: mockSetUser })) },
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+import { createGuestUser, updateGuestUsername } from "@/features/authentication/api/guestApi";
+
+describe("createGuestUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets user with server-provided expiresAt (line 28 true)", async () => {
+    const futureTime = Date.now() + 1000;
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { id: "u1", username: "g1", email: "", isGuest: true, expiresAt: futureTime },
+    });
+    const result = await createGuestUser();
+    expect(result.success).toBe(true);
+    expect(mockSetUser).toHaveBeenCalledWith(expect.objectContaining({ expiresAt: futureTime }));
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "success" }));
+  });
+
+  it("falls back to 48h default when expiresAt is missing (line 28 false)", async () => {
+    const before = Date.now();
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { id: "u2", username: "g2", email: "", isGuest: true },
+    });
+    await createGuestUser();
+    const callArg = mockSetUser.mock.calls[0][0];
+    expect(callArg.expiresAt).toBeGreaterThanOrEqual(before + 48 * 3600 * 1000 - 100);
+  });
+
+  it("throws when success=false (line 47 else branch)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "no" });
+    await expect(createGuestUser()).rejects.toThrow("Failed to create guest user account");
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+  });
+
+  it("uses error.message in toast for Error instance in catch (line 55 true)", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Network failure"));
+    await expect(createGuestUser()).rejects.toThrow("Network failure");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Network failure", type: "error" }),
+    );
+  });
+
+  it("uses 'An error occurred' for non-Error in catch (line 55 false)", async () => {
+    mockPost.mockRejectedValueOnce("plain string error");
+    await expect(createGuestUser()).rejects.toBe("plain string error");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "An error occurred", type: "error" }),
+    );
+  });
+});
+
+describe("updateGuestUsername", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates user store and shows success toast on success", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { username: "newname" },
+    });
+    const result = await updateGuestUsername("newname");
+    expect(result.success).toBe(true);
+    expect(mockSetUser).toHaveBeenCalledWith({ username: "newname" });
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "success" }));
+  });
+
+  it("throws when success=false (else branch)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "bad" });
+    await expect(updateGuestUsername("x")).rejects.toThrow(
+      "Failed to update guest user account",
+    );
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+  });
+
+  it("uses error.message in toast for Error instance in catch", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Username taken"));
+    await expect(updateGuestUsername("taken")).rejects.toThrow("Username taken");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Username taken", type: "error" }),
+    );
+  });
+
+  it("uses 'An error occurred' for non-Error in catch", async () => {
+    mockPost.mockRejectedValueOnce(42);
+    await expect(updateGuestUsername("x")).rejects.toBe(42);
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "An error occurred", type: "error" }),
+    );
+  });
+});

--- a/client-app/src/tests/features/authentication/passwordResetApi.test.ts
+++ b/client-app/src/tests/features/authentication/passwordResetApi.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Branch coverage for passwordResetApi.ts:
+ * requestPasswordReset:
+ *   - success=true → success toast returned
+ *   - success=false → throws, error toast (Error instance)
+ *   - httpClient throws (non-Error) → error toast with generic message
+ * verifyResetToken:
+ *   - success → returns response
+ *   - httpClient throws → error toast, rethrows
+ * resetPassword:
+ *   - success=true → success toast
+ *   - success=false → throws (Error instance), error toast
+ *   - httpClient throws (non-Error) → generic error toast
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPost, mockToasterCreate } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockToasterCreate: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: mockPost },
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+import {
+  requestPasswordReset,
+  verifyResetToken,
+  resetPassword,
+} from "@/features/authentication/api/passwordResetApi";
+
+describe("requestPasswordReset", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows success toast and returns response when success=true", async () => {
+    mockPost.mockResolvedValueOnce({ success: true, message: "sent" });
+    const result = await requestPasswordReset("a@b.com");
+    expect(result.success).toBe(true);
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+  });
+
+  it("throws and shows error toast when success=false (else branch)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "No user found" });
+    await expect(requestPasswordReset("x@y.com")).rejects.toThrow("No user found");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", description: "No user found" }),
+    );
+  });
+
+  it("shows generic error description for non-Error in catch (line 46 false)", async () => {
+    mockPost.mockRejectedValueOnce("network glitch");
+    await expect(requestPasswordReset("x@y.com")).rejects.toBe("network glitch");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        description:
+          "There was an error sending the password reset email. Please try again.",
+      }),
+    );
+  });
+});
+
+describe("verifyResetToken", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns response without showing a toast on success", async () => {
+    mockPost.mockResolvedValueOnce({ success: true, data: { userId: "u1", validUntil: 9999 } });
+    const result = await verifyResetToken("tok123");
+    expect(result.success).toBe(true);
+    expect(result.data?.userId).toBe("u1");
+    expect(mockToasterCreate).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast and rethrows when httpClient throws", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Expired token"));
+    await expect(verifyResetToken("bad-tok")).rejects.toThrow("Expired token");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
+  });
+});
+
+describe("resetPassword", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows success toast and returns response when success=true", async () => {
+    mockPost.mockResolvedValueOnce({ success: true, message: "done" });
+    const result = await resetPassword("tok", "newpass123");
+    expect(result.success).toBe(true);
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+  });
+
+  it("throws and shows error toast with message when success=false (Error instance)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false, message: "Token invalid" });
+    await expect(resetPassword("bad-tok", "newpass")).rejects.toThrow("Token invalid");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", description: "Token invalid" }),
+    );
+  });
+
+  it("shows generic error description for non-Error in catch (line 111 false)", async () => {
+    mockPost.mockRejectedValueOnce(42);
+    await expect(resetPassword("tok", "newpass")).rejects.toBe(42);
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        description: "There was an error resetting your password. Please try again.",
+      }),
+    );
+  });
+});

--- a/client-app/src/tests/features/authentication/registrationApi.test.ts
+++ b/client-app/src/tests/features/authentication/registrationApi.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Branch coverage for registrationApi.ts:
+ * registerUser:
+ *   - success + data.password → calls loginUser auto-login
+ *   - success + NO password → uses setUser from store directly (else branch line 43)
+ *   - success + loginUser throws → warning toast (inner catch line 54)
+ *   - httpClient.post throws → outer catch, error toast (Error instance, line 68)
+ *   - httpClient.post throws (non-Error) → generic description (line 69)
+ * userExists:
+ *   - returns true when data.exists=true
+ *   - returns false when data.exists=false
+ *   - rethrows when httpClient throws
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPost, mockGet, mockSetUser, mockToasterCreate, mockLoginUser } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockGet: vi.fn(),
+  mockSetUser: vi.fn(),
+  mockToasterCreate: vi.fn(),
+  mockLoginUser: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: mockPost, get: mockGet },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: { getState: vi.fn(() => ({ setUser: mockSetUser })) },
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+vi.mock("@/features/authentication/api/authenticationApi", () => ({
+  loginUser: mockLoginUser,
+}));
+
+import { registerUser, userExists } from "@/features/authentication/api/registrationApi";
+
+describe("registerUser", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls loginUser auto-login when password is provided (line 38 true branch)", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { id: "u1", username: "Grimgork", email: "g@g.com" },
+    });
+    mockLoginUser.mockResolvedValueOnce({ success: true });
+    const result = await registerUser({
+      username: "Grimgork",
+      email: "g@g.com",
+      password: "hunter123",
+    });
+    expect(result.success).toBe(true);
+    expect(mockLoginUser).toHaveBeenCalledWith({
+      identifier: "g@g.com",
+      password: "hunter123",
+    });
+    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "success" }));
+  });
+
+  it("sets user directly when no password is provided (line 43 else branch)", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { id: "u2", username: "NoPass", email: "np@g.com" },
+    });
+    await registerUser({ username: "NoPass", email: "np@g.com" });
+    expect(mockLoginUser).not.toHaveBeenCalled();
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({ username: "NoPass", isAuthenticated: true }),
+    );
+  });
+
+  it("shows warning toast when auto-login throws (inner catch line 54)", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { id: "u3", username: "AutoFail", email: "af@g.com" },
+    });
+    mockLoginUser.mockRejectedValueOnce(new Error("Login error"));
+    await registerUser({ username: "AutoFail", email: "af@g.com", password: "pass1234" });
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" }),
+    );
+  });
+
+  it("shows error toast with message for Error instance in outer catch (line 68)", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Email already exists"));
+    await expect(
+      registerUser({ username: "Dup", email: "d@d.com", password: "pass1234" }),
+    ).rejects.toThrow("Email already exists");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        description: "Email already exists",
+      }),
+    );
+  });
+
+  it("shows generic description for non-Error in outer catch (line 69)", async () => {
+    mockPost.mockRejectedValueOnce("raw error");
+    await expect(
+      registerUser({ username: "X", email: "x@x.com", password: "pass1234" }),
+    ).rejects.toBe("raw error");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        description: "Failed to register your account",
+      }),
+    );
+  });
+});
+
+describe("userExists", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns true when server says exists=true", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: { exists: true } });
+    const result = await userExists("existing@user.com");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when server says exists=false", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: { exists: false } });
+    const result = await userExists("new@user.com");
+    expect(result).toBe(false);
+  });
+
+  it("rethrows when httpClient throws", async () => {
+    mockGet.mockRejectedValueOnce(new Error("Network error"));
+    await expect(userExists("x@x.com")).rejects.toThrow("Network error");
+  });
+});

--- a/client-app/src/tests/features/contact/ContactPage.test.tsx
+++ b/client-app/src/tests/features/contact/ContactPage.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Branch coverage for contact/components/ContactPage.tsx:
+ * - FaqItem open=false (initial): Collapsible data-state="closed"
+ * - FaqItem open=true (after click): Collapsible data-state="open" (open state branch)
+ * - Clicking open item again: data-state back to "closed" (close branch)
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import ContactPage from "@/features/contact/components/ContactPage";
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <ContactPage />
+    </ChakraProvider>,
+  );
+}
+
+function getFaqRoot(questionText: RegExp) {
+  const text = screen.getByText(questionText);
+  return text.closest('[data-scope="collapsible"]') as HTMLElement;
+}
+
+describe("ContactPage", () => {
+  it("renders 'Get Help' heading", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: "Get Help", level: 1 })).toBeInTheDocument();
+  });
+
+  it("renders FAQ section heading", () => {
+    renderPage();
+    expect(screen.getByText("Frequently Asked Questions")).toBeInTheDocument();
+  });
+});
+
+describe("FaqItem – open/close toggle (line 49 branch)", () => {
+  it("starts closed (data-state=closed, open=false branch)", () => {
+    renderPage();
+    const root = getFaqRoot(/Can I change a result after/i);
+    expect(root.getAttribute("data-state")).toBe("closed");
+  });
+
+  it("opens on click (data-state=open, open=true branch)", async () => {
+    renderPage();
+    const root = getFaqRoot(/Can I change a result after/i);
+    const trigger = screen.getByText(/Can I change a result after/i);
+    await userEvent.click(trigger);
+    expect(root.getAttribute("data-state")).toBe("open");
+  });
+
+  it("closes again on second click (toggling back to closed)", async () => {
+    renderPage();
+    const root = getFaqRoot(/Can I change a result after/i);
+    const trigger = screen.getByText(/Can I change a result after/i);
+    await userEvent.click(trigger);
+    expect(root.getAttribute("data-state")).toBe("open");
+    await userEvent.click(trigger);
+    expect(root.getAttribute("data-state")).toBe("closed");
+  });
+});

--- a/client-app/src/tests/features/terms/PrivacyPolicyPage.test.tsx
+++ b/client-app/src/tests/features/terms/PrivacyPolicyPage.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Render coverage for terms/components/PrivacyPolicyPage.tsx (static content page)
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+vi.mock("@/shared/ui/Prose", () => ({
+  Prose: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import PrivacyPolicyPage from "@/features/terms/components/PrivacyPolicyPage";
+
+describe("PrivacyPolicyPage", () => {
+  it("renders 'Privacy Policy' heading", () => {
+    render(
+      <ChakraProvider value={defaultSystem}>
+        <PrivacyPolicyPage />
+      </ChakraProvider>,
+    );
+    expect(screen.getByRole("heading", { name: /privacy policy/i })).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/terms/TermsPage.test.tsx
+++ b/client-app/src/tests/features/terms/TermsPage.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * Render coverage for terms/components/TermsPage.tsx (static content page)
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/shared/ui/Prose", () => ({
+  Prose: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import TermsPage from "@/features/terms/components/TermsPage";
+
+describe("TermsPage", () => {
+  it("renders 'Terms of Use' heading", () => {
+    render(
+      <MemoryRouter>
+        <ChakraProvider value={defaultSystem}>
+          <TermsPage />
+        </ChakraProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("heading", { name: /terms of use/i })).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/tournaments/TournamentByCode.test.tsx
+++ b/client-app/src/tests/features/tournaments/TournamentByCode.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Branch coverage for TournamentByCode.tsx:
+ * - notFound=false, !resolvedId → shows Spinner (loading state)
+ * - notFound=true → shows "Tournament Not Found" message
+ * - resolvedId set → renders TournamentViewPage with the id
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { get: mockGet },
+}));
+
+vi.mock(
+  "@/features/tournaments/components/TournamentViewPage",
+  () => ({
+    default: ({ id }: { id: string }) => <div data-testid="view-page">id:{id}</div>,
+  }),
+);
+
+import TournamentByCode from "@/features/tournaments/components/TournamentByCode";
+
+function renderWithCode(code = "ABC123") {
+  return render(
+    <MemoryRouter initialEntries={[`/spectate/${code}`]}>
+      <ChakraProvider value={defaultSystem}>
+        <Routes>
+          <Route path="/spectate/:code" element={<TournamentByCode />} />
+        </Routes>
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("TournamentByCode – loading state (!resolvedId, !notFound)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows Spinner while the API request is in flight", () => {
+    // Never-resolving promise keeps us in loading state
+    mockGet.mockReturnValueOnce(new Promise(() => {}));
+    renderWithCode();
+    // Chakra Spinner renders a div with role="status" by default
+    const spinner = document.querySelector("[data-scope='spinner']")
+      ?? document.querySelector("svg[aria-label]")
+      ?? document.querySelector(".chakra-spinner");
+    // Check for loading indicator
+    expect(spinner ?? screen.queryByText(/tournament not found/i)).not.toBeNull();
+    expect(screen.queryByText(/tournament not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("TournamentByCode – notFound=true (catch branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Tournament Not Found' when API rejects", async () => {
+    mockGet.mockRejectedValueOnce(new Error("Not found"));
+    renderWithCode("ZZZ999");
+    await waitFor(() =>
+      expect(screen.getByText(/tournament not found/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/ZZZ999/i)).toBeInTheDocument();
+  });
+});
+
+describe("TournamentByCode – resolvedId set (success path)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders TournamentViewPage with the resolved id", async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: { _id: "tour-123" } });
+    renderWithCode("ABC123");
+    await waitFor(() =>
+      expect(screen.getByTestId("view-page")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("id:tour-123")).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/tournaments/bracket/MatchParticipantSlot.test.tsx
+++ b/client-app/src/tests/features/tournaments/bracket/MatchParticipantSlot.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Branch coverage for bracket/MatchParticipantSlot.tsx:
+ * - participantId=null → shows "Drop player here" (null branch, line 25-27)
+ * - participantId set and participant found → shows name + faction + Remove button (truthy branch)
+ * - onRemove callback fires when Remove button is clicked
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+vi.mock("@dnd-kit/core", () => ({
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+}));
+
+import { MatchParticipantSlot } from "@/features/tournaments/components/bracket/MatchParticipantSlot";
+
+const participants = [
+  { id: "p1", name: "Grimgork", faction: "Orks" },
+  { id: "p2", name: "Sigmar", faction: "Empire" },
+];
+
+function renderSlot(participantId: string | null, onRemove = vi.fn()) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <MatchParticipantSlot
+        matchId="m1"
+        position={1}
+        participantId={participantId}
+        participants={participants}
+        onRemove={onRemove}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("MatchParticipantSlot – empty slot (participantId=null)", () => {
+  it("shows 'Drop player here' when no participant assigned", () => {
+    renderSlot(null);
+    expect(screen.getByText(/drop player here/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchParticipantSlot – filled slot (participant found)", () => {
+  it("shows participant name and faction", () => {
+    renderSlot("p1");
+    expect(screen.getByText("Grimgork")).toBeInTheDocument();
+    expect(screen.getByText("Orks")).toBeInTheDocument();
+  });
+
+  it("calls onRemove when the Remove button is clicked", async () => {
+    const onRemove = vi.fn();
+    renderSlot("p2", onRemove);
+    await userEvent.click(screen.getByRole("button", { name: /remove participant/i }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client-app/src/tests/features/tournaments/bracket/SortableItem.test.tsx
+++ b/client-app/src/tests/features/tournaments/bracket/SortableItem.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Branch coverage for bracket/SortableItem.tsx:
+ * - isDragging=false (line 27-28, 40): zIndex=1, opacity=1, bg="transparent"
+ * - isDragging=true (line 27-28, 40): zIndex=10, opacity=0.8, bg="info.subtle"
+ * - participant name and faction are rendered
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const mockUseSortable = vi.fn();
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: (args: unknown) => mockUseSortable(args),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: (t: unknown) => (t ? String(t) : undefined) } },
+}));
+
+import { SortableItem } from "@/features/tournaments/components/bracket/SortableItem";
+
+function makeSortableReturn(isDragging: boolean) {
+  return {
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging,
+  };
+}
+
+function renderItem(isDragging: boolean) {
+  mockUseSortable.mockReturnValue(makeSortableReturn(isDragging));
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <SortableItem
+        id="p1"
+        participant={{ id: "p1", name: "Grimgork", faction: "Orks" }}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("SortableItem – not dragging (isDragging=false)", () => {
+  it("renders participant name and faction", () => {
+    renderItem(false);
+    expect(screen.getByText("Grimgork")).toBeInTheDocument();
+    expect(screen.getByText("Orks")).toBeInTheDocument();
+  });
+
+  it("applies zIndex=1 and opacity=1 when not dragging", () => {
+    const { container } = renderItem(false);
+    const box = container.firstChild as HTMLElement;
+    expect(box.style.zIndex).toBe("1");
+    expect(box.style.opacity).toBe("1");
+  });
+});
+
+describe("SortableItem – dragging (isDragging=true)", () => {
+  it("applies zIndex=10 and opacity=0.8 when dragging", () => {
+    const { container } = renderItem(true);
+    const box = container.firstChild as HTMLElement;
+    expect(box.style.zIndex).toBe("10");
+    expect(box.style.opacity).toBe("0.8");
+  });
+});


### PR DESCRIPTION
## Summary

- **PasswordResetForm**: Back button → `onBackClick`; `requestPasswordReset` success → `onSuccess`; reject → `onSuccess` not called
- **RegistrationForm**: success → `navigate("/")`; reject → no navigate (catch branch)
- **ResetPasswordPage**: 6 state branches — no token in URL (invalid immediately), loading state (in-flight verify), `success=false` (invalid), `success=true + validUntil` (expiry shown), `success=true + no validUntil` (no expiry), `verifyResetToken` throws (catch branch → invalid)
- **TermsPage**: smoke render — "Terms of Use" heading present
- **PrivacyPolicyPage**: smoke render — "Privacy Policy" heading present

## Test plan

- [x] All 13 tests pass locally
- [x] `window.location.search` overridden per-test to control token presence
- [x] `PasswordInput` mocked as a forwardRef native `<input>` to avoid Chakra complexity

https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm)_