### PR TITLE
test(batch11): branch coverage for MatchCard, socketClient, PasswordInput, ColorMode, displayName

### DIFF
--- a/client-app/src/tests/core/socketClient.test.ts
+++ b/client-app/src/tests/core/socketClient.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Branch coverage for core/socket/socketClient.ts:
+ * - getSocket(): !socket (first call) → creates new socket via io()
+ * - getSocket(): socket exists (second call) → returns same instance
+ * - apiConfig.baseUrl truthy + valid URL → uses new URL(baseUrl).origin
+ * - apiConfig.baseUrl empty → uses window.location.origin
+ * - apiConfig.baseUrl invalid URL → catch block → uses window.location.origin
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSocketInstance, mockIo, mockApiConfig } = vi.hoisted(() => {
+  const inst = {
+    on: vi.fn(),
+    io: {
+      on: vi.fn(),
+      engine: { on: vi.fn() },
+    },
+  };
+  return {
+    mockSocketInstance: inst,
+    mockIo: vi.fn().mockReturnValue(inst),
+    mockApiConfig: { baseUrl: "" },
+  };
+});
+
+vi.mock("socket.io-client", () => ({ io: mockIo }));
+vi.mock("@/core/config/apiConfig", () => ({ apiConfig: mockApiConfig }));
+
+describe("getSocket – singleton and URL logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockIo.mockReturnValue(mockSocketInstance);
+  });
+
+  it("creates socket on first call and returns the instance", async () => {
+    mockApiConfig.baseUrl = "";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    const s = getSocket();
+    expect(s).toBe(mockSocketInstance);
+    expect(mockIo).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the same socket instance on subsequent calls (singleton)", async () => {
+    mockApiConfig.baseUrl = "";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    const s1 = getSocket();
+    const s2 = getSocket();
+    expect(s1).toBe(s2);
+    expect(mockIo).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses origin of apiConfig.baseUrl when baseUrl is a valid URL", async () => {
+    mockApiConfig.baseUrl = "http://api.example.com/api/v1";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    getSocket();
+    expect(mockIo).toHaveBeenCalledWith(
+      "http://api.example.com",
+      expect.any(Object),
+    );
+  });
+
+  it("uses window.location.origin when baseUrl is empty string", async () => {
+    mockApiConfig.baseUrl = "";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    getSocket();
+    expect(mockIo).toHaveBeenCalledWith(
+      window.location.origin,
+      expect.any(Object),
+    );
+  });
+
+  it("falls back to window.location.origin when baseUrl is not a valid URL (catch branch)", async () => {
+    mockApiConfig.baseUrl = "not-a-valid-url";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    getSocket();
+    expect(mockIo).toHaveBeenCalledWith(
+      window.location.origin,
+      expect.any(Object),
+    );
+  });
+});

--- a/client-app/src/tests/features/matches/MatchCard.test.tsx
+++ b/client-app/src/tests/features/matches/MatchCard.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * Branch coverage for matches/components/MatchCard.tsx:
+ * - m.status === "pending" → "Pending" badge
+ * - m.status === "in_progress" → "In Progress" badge
+ * - m.status === "completed" → "Completed" badge
+ * - m.status === "disputed" → "⚠ Disputed" badge
+ * - p1Won → W badge on player1
+ * - m.winnerId && !p1Won → L badge on player1
+ * - p2Won → W badge on player2
+ * - m.winnerId && !p2Won && player2 !== "BYE" → L badge on player2
+ * - player2.name === "BYE" → no L badge
+ * - resultOverrides.length > 0 → "Overridden" button shown
+ * - resultOverrides.length > 1 → "2×" count prefix
+ * - m.winnerId → Winner section shown
+ * - canParticipantReport + no myReport → "Who won this match?"
+ * - canParticipantReport + myReport → "Change your reported winner:"
+ * - isOverriding → override panel, Cancel/Confirm buttons
+ * - isOverriding + resultOverrides.length===1 → "overridden once" message
+ * - isAdmin && isActive && status !== completed/disputed → record result buttons
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import MatchCard from "@/features/matches/components/MatchCard";
+
+const baseMatch = {
+  _id: "m1",
+  round: 1,
+  matchNumber: 1,
+  player1: { participantId: "p1", name: "Grimgork", faction: "Greenskins" },
+  player2: { participantId: "p2", name: "Luthor", faction: "Empire" },
+  winnerId: null as string | null,
+  loserId: null as string | null,
+  status: "pending" as "pending" | "in_progress" | "completed" | "disputed",
+  notes: "",
+  reportedResults: [] as {
+    reportedBy: string;
+    reportedByName: string;
+    winnerId: string;
+  }[],
+  resultOverrides: [] as {
+    previousWinnerId: string | null;
+    newWinnerId: string;
+    overriddenBy: string;
+    reason: string;
+    overriddenAt: string;
+  }[],
+  completedAt: null as string | null,
+  bracketSide: null as "winners" | "losers" | "grand_final" | null,
+};
+
+const baseFns = {
+  onRecordResult: vi.fn(),
+  onReportResult: vi.fn(),
+  onResolveDispute: vi.fn(),
+  onStartOverride: vi.fn(),
+  onCancelOverride: vi.fn(),
+  onSetOverrideWinner: vi.fn(),
+  onSetOverrideReason: vi.fn(),
+  onConfirmOverride: vi.fn(),
+};
+
+function renderCard(
+  matchOverride: Partial<typeof baseMatch> = {},
+  extraProps: Record<string, unknown> = {},
+) {
+  const m = { ...baseMatch, ...matchOverride };
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <MatchCard
+        m={m}
+        p1Won={false}
+        p2Won={false}
+        isOverriding={false}
+        isAdmin={false}
+        isActive={false}
+        myReport={undefined}
+        canParticipantReport={false}
+        isP1={false}
+        isP2={false}
+        actionLoading={false}
+        overrideLoading={false}
+        overrideWinnerId=""
+        overrideReason=""
+        borderColor="border"
+        mutedBg="bg.subtle"
+        {...baseFns}
+        {...extraProps}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("MatchCard – status badges", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Pending' badge for status=pending", () => {
+    renderCard({ status: "pending" });
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("shows 'In Progress' badge for status=in_progress", () => {
+    renderCard({ status: "in_progress" });
+    expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Completed' badge for status=completed", () => {
+    renderCard({ status: "completed" });
+    expect(screen.getByText(/completed/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Disputed' badge for status=disputed", () => {
+    renderCard({ status: "disputed" });
+    expect(screen.getByText(/disputed/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – W/L badges", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows W badge when p1Won=true", () => {
+    renderCard(
+      { status: "completed", winnerId: "p1" },
+      { p1Won: true, p2Won: false },
+    );
+    const wBadges = screen.getAllByText("W");
+    expect(wBadges.length).toBeGreaterThan(0);
+  });
+
+  it("shows L badge on player1 when winnerId is set and !p1Won", () => {
+    renderCard(
+      { status: "completed", winnerId: "p2" },
+      { p1Won: false, p2Won: true },
+    );
+    expect(screen.getByText("L")).toBeInTheDocument();
+  });
+
+  it("shows W badge when p2Won=true", () => {
+    renderCard(
+      { status: "completed", winnerId: "p2" },
+      { p1Won: false, p2Won: true },
+    );
+    const wBadges = screen.getAllByText("W");
+    expect(wBadges.length).toBeGreaterThan(0);
+  });
+
+  it("does not show L badge for player2 when player2 is BYE", () => {
+    renderCard(
+      {
+        status: "completed",
+        winnerId: "p1",
+        player2: { participantId: "bye", name: "BYE", faction: "" },
+      },
+      { p1Won: true, p2Won: false },
+    );
+    expect(screen.queryByText("L")).not.toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – resultOverrides button", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Overridden' trigger when resultOverrides.length > 0", () => {
+    renderCard({
+      resultOverrides: [
+        {
+          previousWinnerId: null,
+          newWinnerId: "p1",
+          overriddenBy: "admin1",
+          reason: "cheating",
+          overriddenAt: new Date().toISOString(),
+        },
+      ],
+    });
+    expect(screen.getByText(/overridden/i)).toBeInTheDocument();
+  });
+
+  it("shows '2×' count prefix when resultOverrides.length > 1", () => {
+    renderCard({
+      resultOverrides: [
+        {
+          previousWinnerId: null,
+          newWinnerId: "p1",
+          overriddenBy: "admin1",
+          reason: "",
+          overriddenAt: new Date().toISOString(),
+        },
+        {
+          previousWinnerId: "p1",
+          newWinnerId: "p2",
+          overriddenBy: "admin1",
+          reason: "",
+          overriddenAt: new Date().toISOString(),
+        },
+      ],
+    });
+    expect(screen.getByText(/2×/)).toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – Winner section", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows Winner section when m.winnerId is set", () => {
+    renderCard({ winnerId: "p1", status: "completed" });
+    expect(screen.getByText(/winner:/i)).toBeInTheDocument();
+  });
+
+  it("does not show Winner section when m.winnerId is null", () => {
+    renderCard({ winnerId: null });
+    expect(screen.queryByText(/winner:/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – canParticipantReport (myReport branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Who won this match?' when no myReport", () => {
+    renderCard(
+      { status: "in_progress" },
+      { canParticipantReport: true, myReport: undefined },
+    );
+    expect(screen.getByText(/who won this match/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Change your reported winner:' when myReport is present", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        canParticipantReport: true,
+        myReport: {
+          reportedBy: "u1",
+          reportedByName: "User",
+          winnerId: "p1",
+        },
+      },
+    );
+    expect(screen.getByText(/change your reported winner/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – isOverriding panel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows override panel with Confirm Override button", () => {
+    renderCard({}, { isOverriding: true });
+    expect(screen.getByText(/override result/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /confirm override/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onCancelOverride when Cancel is clicked", () => {
+    const onCancelOverride = vi.fn();
+    renderCard({}, { isOverriding: true, onCancelOverride });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancelOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows 'overridden once' message when resultOverrides.length === 1", () => {
+    renderCard(
+      {
+        resultOverrides: [
+          {
+            previousWinnerId: null,
+            newWinnerId: "p1",
+            overriddenBy: "admin1",
+            reason: "",
+            overriddenAt: new Date().toISOString(),
+          },
+        ],
+      },
+      { isOverriding: true },
+    );
+    expect(screen.getByText(/overridden once/i)).toBeInTheDocument();
+  });
+
+  it("shows 'N times' message when resultOverrides.length > 1", () => {
+    renderCard(
+      {
+        resultOverrides: [
+          {
+            previousWinnerId: null,
+            newWinnerId: "p1",
+            overriddenBy: "admin1",
+            reason: "",
+            overriddenAt: new Date().toISOString(),
+          },
+          {
+            previousWinnerId: "p1",
+            newWinnerId: "p2",
+            overriddenBy: "admin1",
+            reason: "",
+            overriddenAt: new Date().toISOString(),
+          },
+        ],
+      },
+      { isOverriding: true },
+    );
+    expect(screen.getByText(/2 times/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – admin record-result buttons", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Record result' section for admin (not p1/p2, status=pending, player2 not BYE)", () => {
+    renderCard(
+      { status: "pending" },
+      { isAdmin: true, isActive: true, isP1: false, isP2: false },
+    );
+    expect(screen.getByText(/record result/i)).toBeInTheDocument();
+  });
+
+  it("calls onRecordResult when admin clicks player1 wins", () => {
+    const onRecordResult = vi.fn();
+    renderCard(
+      { status: "pending" },
+      { isAdmin: true, isActive: true, isP1: false, isP2: false, onRecordResult },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /grimgork wins/i }));
+    expect(onRecordResult).toHaveBeenCalledWith("m1", "p1");
+  });
+});

--- a/client-app/src/tests/shared/ui/ColorMode.test.tsx
+++ b/client-app/src/tests/shared/ui/ColorMode.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Branch coverage for shared/ui/ColorMode.tsx:
+ * - toggleColorMode: resolvedTheme === "dark" → setTheme("light")
+ * - toggleColorMode: resolvedTheme !== "dark" → setTheme("dark")
+ * - useColorModeValue: colorMode === "dark" → returns dark value
+ * - useColorModeValue: colorMode !== "dark" → returns light value
+ * - ColorModeIcon: colorMode === "dark" → renders LuMoon
+ * - ColorModeIcon: colorMode !== "dark" → renders LuSun
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, renderHook, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const { mockUseTheme } = vi.hoisted(() => ({
+  mockUseTheme: vi.fn(),
+}));
+
+vi.mock("next-themes", () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTheme: mockUseTheme,
+}));
+
+vi.mock("react-icons/lu", () => ({
+  LuMoon: () => <span data-testid="icon-moon" />,
+  LuSun: () => <span data-testid="icon-sun" />,
+  LuEye: () => null,
+  LuEyeOff: () => null,
+}));
+
+import {
+  useColorMode,
+  useColorModeValue,
+  ColorModeIcon,
+  ColorModeButton,
+} from "@/shared/ui/ColorMode";
+
+describe("useColorMode – toggleColorMode branch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls setTheme('light') when resolvedTheme is 'dark'", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+    });
+    const { result } = renderHook(() => useColorMode());
+    act(() => result.current.toggleColorMode());
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("calls setTheme('dark') when resolvedTheme is 'light'", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "light",
+      setTheme: mockSetTheme,
+    });
+    const { result } = renderHook(() => useColorMode());
+    act(() => result.current.toggleColorMode());
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("exposes colorMode and setColorMode from useTheme", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+    });
+    const { result } = renderHook(() => useColorMode());
+    expect(result.current.colorMode).toBe("dark");
+    expect(result.current.setColorMode).toBe(mockSetTheme);
+  });
+});
+
+describe("useColorModeValue – dark vs light branch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the light value when colorMode is 'light'", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light", setTheme: vi.fn() });
+    const { result } = renderHook(() =>
+      useColorModeValue("light-value", "dark-value"),
+    );
+    expect(result.current).toBe("light-value");
+  });
+
+  it("returns the dark value when colorMode is 'dark'", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "dark", setTheme: vi.fn() });
+    const { result } = renderHook(() =>
+      useColorModeValue("light-value", "dark-value"),
+    );
+    expect(result.current).toBe("dark-value");
+  });
+});
+
+describe("ColorModeIcon – moon vs sun", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders LuMoon when colorMode is 'dark'", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "dark", setTheme: vi.fn() });
+    render(<ColorModeIcon />);
+    expect(screen.getByTestId("icon-moon")).toBeInTheDocument();
+    expect(screen.queryByTestId("icon-sun")).not.toBeInTheDocument();
+  });
+
+  it("renders LuSun when colorMode is 'light'", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light", setTheme: vi.fn() });
+    render(<ColorModeIcon />);
+    expect(screen.getByTestId("icon-sun")).toBeInTheDocument();
+    expect(screen.queryByTestId("icon-moon")).not.toBeInTheDocument();
+  });
+});
+
+describe("ColorModeButton – click triggers toggleColorMode", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls setTheme('light') when clicked in dark mode", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+    });
+    render(
+      <ChakraProvider value={defaultSystem}>
+        <ColorModeButton />
+      </ChakraProvider>,
+    );
+    const btn = screen.getByRole("button", { name: /toggle color mode/i });
+    fireEvent.click(btn);
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("calls setTheme('dark') when clicked in light mode", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "light",
+      setTheme: mockSetTheme,
+    });
+    render(
+      <ChakraProvider value={defaultSystem}>
+        <ColorModeButton />
+      </ChakraProvider>,
+    );
+    const btn = screen.getByRole("button", { name: /toggle color mode/i });
+    fireEvent.click(btn);
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+});

--- a/client-app/src/tests/shared/ui/PasswordInput.test.tsx
+++ b/client-app/src/tests/shared/ui/PasswordInput.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Branch coverage for shared/ui/PasswordInput.tsx:
+ * PasswordInput:
+ *   - visible=false (default) → type="password", shows LuEye icon
+ *   - after toggle → type="text", shows LuEyeOff icon
+ *   - onPointerDown disabled guard: rest.disabled=true → no toggle
+ *   - onPointerDown button guard: e.button !== 0 → no toggle
+ * PasswordStrengthMeter (getColorPalette):
+ *   - percent < 33 → "Low" label
+ *   - percent < 66 → "Medium" label
+ *   - default (percent >= 66) → "High" label
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { PasswordInput, PasswordStrengthMeter } from "@/shared/ui/PasswordInput";
+
+function renderPasswordInput(props: React.ComponentProps<typeof PasswordInput> = {}) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PasswordInput placeholder="password" data-testid="pwd-input" {...props} />
+    </ChakraProvider>,
+  );
+}
+
+describe("PasswordInput – initial type", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders as type='password' by default", () => {
+    const { container } = renderPasswordInput();
+    const input = container.querySelector("input");
+    expect(input).toHaveAttribute("type", "password");
+  });
+});
+
+describe("PasswordInput – toggle visibility", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("switches to type='text' after clicking the toggle button", () => {
+    const { container } = renderPasswordInput();
+    const toggleBtn = screen.getByRole("button", {
+      name: /toggle password visibility/i,
+    });
+    fireEvent.pointerDown(toggleBtn, { button: 0 });
+    expect(container.querySelector("input")).toHaveAttribute("type", "text");
+  });
+
+  it("switches back to type='password' after clicking toggle twice", () => {
+    const { container } = renderPasswordInput();
+    const toggleBtn = screen.getByRole("button", {
+      name: /toggle password visibility/i,
+    });
+    fireEvent.pointerDown(toggleBtn, { button: 0 });
+    fireEvent.pointerDown(toggleBtn, { button: 0 });
+    expect(container.querySelector("input")).toHaveAttribute("type", "password");
+  });
+});
+
+describe("PasswordInput – onPointerDown guards", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not toggle when disabled prop is true", () => {
+    const { container } = renderPasswordInput({ disabled: true });
+    const toggleBtn = screen.getByRole("button", {
+      name: /toggle password visibility/i,
+    });
+    fireEvent.pointerDown(toggleBtn, { button: 0 });
+    expect(container.querySelector("input")).toHaveAttribute("type", "password");
+  });
+
+  it("does not toggle when pointer button is not 0 (non-left-click)", () => {
+    const { container } = renderPasswordInput();
+    const toggleBtn = screen.getByRole("button", {
+      name: /toggle password visibility/i,
+    });
+    fireEvent.pointerDown(toggleBtn, { button: 1 });
+    expect(container.querySelector("input")).toHaveAttribute("type", "password");
+  });
+});
+
+describe("PasswordInput – defaultVisible prop", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders as type='text' when defaultVisible=true", () => {
+    const { container } = renderPasswordInput({ defaultVisible: true });
+    expect(container.querySelector("input")).toHaveAttribute("type", "text");
+  });
+});
+
+function renderMeter(value: number, max = 4) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PasswordStrengthMeter value={value} max={max} />
+    </ChakraProvider>,
+  );
+}
+
+describe("PasswordStrengthMeter – getColorPalette labels", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Low' label when percent < 33 (value=0)", () => {
+    renderMeter(0);
+    expect(screen.getByText("Low")).toBeInTheDocument();
+  });
+
+  it("shows 'Medium' label when 33 ≤ percent < 66 (value=2, max=4 → 50%)", () => {
+    renderMeter(2, 4);
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+  });
+
+  it("shows 'High' label when percent >= 66 (value=4, max=4 → 100%)", () => {
+    renderMeter(4, 4);
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+
+  it("shows 'Low' for 1 out of 4 (25%)", () => {
+    renderMeter(1, 4);
+    expect(screen.getByText("Low")).toBeInTheDocument();
+  });
+
+  it("shows 'High' for 3 out of 4 (75%)", () => {
+    renderMeter(3, 4);
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/shared/utils/displayName.test.ts
+++ b/client-app/src/tests/shared/utils/displayName.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Branch coverage for shared/utils/displayName.ts:
+ * - !name (null / undefined / "") → "Unknown"
+ * - DELETED_PATTERN.test(name.trim()) → "Deleted User"
+ * - else → name as-is
+ */
+import { describe, it, expect } from "vitest";
+import { displayName } from "@/shared/utils/displayName";
+
+describe("displayName – null / undefined / empty → 'Unknown'", () => {
+  it("returns 'Unknown' for null", () => {
+    expect(displayName(null)).toBe("Unknown");
+  });
+
+  it("returns 'Unknown' for undefined", () => {
+    expect(displayName(undefined)).toBe("Unknown");
+  });
+
+  it("returns 'Unknown' for empty string", () => {
+    expect(displayName("")).toBe("Unknown");
+  });
+});
+
+describe("displayName – deleted_ pattern → 'Deleted User'", () => {
+  it("matches lowercase deleted_ prefix with 8 hex chars", () => {
+    expect(displayName("deleted_12345678")).toBe("Deleted User");
+  });
+
+  it("matches uppercase DELETED_ prefix (case-insensitive)", () => {
+    expect(displayName("DELETED_abcdef01")).toBe("Deleted User");
+  });
+
+  it("matches mixed hex characters after deleted_", () => {
+    expect(displayName("deleted_aAbBcCdD")).toBe("Deleted User");
+  });
+
+  it("trims whitespace before testing", () => {
+    expect(displayName("  deleted_12345678  ")).toBe("Deleted User");
+  });
+
+  it("does NOT match if hex part is not exactly 8 chars", () => {
+    expect(displayName("deleted_1234567")).toBe("deleted_1234567");
+    expect(displayName("deleted_123456789")).toBe("deleted_123456789");
+  });
+
+  it("does NOT match if not at start of string", () => {
+    expect(displayName("xdeleted_12345678")).toBe("xdeleted_12345678");
+  });
+});
+
+describe("displayName – regular names returned as-is", () => {
+  it("returns regular name unchanged", () => {
+    expect(displayName("Grimgork")).toBe("Grimgork");
+  });
+
+  it("returns name with spaces unchanged", () => {
+    expect(displayName("Player One")).toBe("Player One");
+  });
+
+  it("returns name that starts with 'deleted' but does not match full pattern", () => {
+    expect(displayName("deleted_user")).toBe("deleted_user");
+  });
+});


### PR DESCRIPTION
## Summary

- **MatchCard** (20 tests): status badges (pending/in_progress/completed/disputed), W/L badges, BYE player (no L badge), resultOverrides button with count prefix, Winner section, `canParticipantReport` report buttons with `myReport` branch, `isOverriding` panel (cancel, confirm, "overridden once/N times"), admin record-result buttons
- **socketClient** (5 tests): singleton — first call creates socket via `io()`, second call returns same instance; `apiConfig.baseUrl` → `new URL(...).origin`; empty baseUrl → `window.location.origin`; invalid URL → catch fallback to `window.location.origin`
- **PasswordInput + PasswordStrengthMeter** (11 tests): default `type="password"`, toggle to `type="text"` and back; `disabled` guard (no toggle); `button !== 0` guard (no toggle); `defaultVisible=true`; `getColorPalette` Low/Medium/High labels
- **ColorMode** (9 tests): `toggleColorMode` dark→light / light→dark; `useColorModeValue` light/dark branch; `ColorModeIcon` LuMoon/LuSun branch; `ColorModeButton` click in both modes
- **displayName** (12 tests): null/undefined/empty → "Unknown"; `deleted_[a-f0-9]{8}` pattern → "Deleted User" (case-insensitive, trims whitespace, rejects partial matches); regular names returned as-is

## Test plan
- [x] All 57 tests pass locally (`npx vitest run` on each file)
- [x] No existing tests broken

https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm)_