### PR TITLE
test(batch12): branch coverage for UsernameUpdateForm, UserStatsCard, RegisterLogin, StatisticsPage, MatchesSection

### DIFF
--- a/client-app/src/tests/core/socketClient.test.ts
+++ b/client-app/src/tests/core/socketClient.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Branch coverage for core/socket/socketClient.ts:
+ * - getSocket(): !socket (first call) → creates new socket via io()
+ * - getSocket(): socket exists (second call) → returns same instance
+ * - apiConfig.baseUrl truthy + valid URL → uses new URL(baseUrl).origin
+ * - apiConfig.baseUrl empty → uses window.location.origin
+ * - apiConfig.baseUrl invalid URL → catch block → uses window.location.origin
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSocketInstance, mockIo, mockApiConfig } = vi.hoisted(() => {
+  const inst = {
+    on: vi.fn(),
+    io: {
+      on: vi.fn(),
+      engine: { on: vi.fn() },
+    },
+  };
+  return {
+    mockSocketInstance: inst,
+    mockIo: vi.fn().mockReturnValue(inst),
+    mockApiConfig: { baseUrl: "" },
+  };
+});
+
+vi.mock("socket.io-client", () => ({ io: mockIo }));
+vi.mock("@/core/config/apiConfig", () => ({ apiConfig: mockApiConfig }));
+
+describe("getSocket – singleton and URL logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockIo.mockReturnValue(mockSocketInstance);
+  });
+
+  it("creates socket on first call and returns the instance", async () => {
+    mockApiConfig.baseUrl = "";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    const s = getSocket();
+    expect(s).toBe(mockSocketInstance);
+    expect(mockIo).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the same socket instance on subsequent calls (singleton)", async () => {
+    mockApiConfig.baseUrl = "";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    const s1 = getSocket();
+    const s2 = getSocket();
+    expect(s1).toBe(s2);
+    expect(mockIo).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses origin of apiConfig.baseUrl when baseUrl is a valid URL", async () => {
+    mockApiConfig.baseUrl = "http://api.example.com/api/v1";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    getSocket();
+    expect(mockIo).toHaveBeenCalledWith(
+      "http://api.example.com",
+      expect.any(Object),
+    );
+  });
+
+  it("uses window.location.origin when baseUrl is empty string", async () => {
+    mockApiConfig.baseUrl = "";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    getSocket();
+    expect(mockIo).toHaveBeenCalledWith(
+      window.location.origin,
+      expect.any(Object),
+    );
+  });
+
+  it("falls back to window.location.origin when baseUrl is not a valid URL (catch branch)", async () => {
+    mockApiConfig.baseUrl = "not-a-valid-url";
+    const { getSocket } = await import("@/core/socket/socketClient");
+    getSocket();
+    expect(mockIo).toHaveBeenCalledWith(
+      window.location.origin,
+      expect.any(Object),
+    );
+  });
+});

--- a/client-app/src/tests/features/account/UserStatsCard.test.tsx
+++ b/client-app/src/tests/features/account/UserStatsCard.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Branch coverage for account/components/UserStatsCard.tsx:
+ * - loading=true → skeleton state shown, faction skeleton rows shown
+ * - loading=false, stats=null (fetch returns null) → No activity message
+ * - loading=false, stats with factions → shows faction list
+ * - loading=false, stats no factions (empty array) → faction section hidden
+ * - f.count === 1 → "match" (singular)
+ * - f.count > 1 → "matches" (plural)
+ * - matchesPlayed === 0 && tournamentsCreated === 0 → "No activity recorded"
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const { mockFetchUserStats } = vi.hoisted(() => ({
+  mockFetchUserStats: vi.fn(),
+}));
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  fetchUserStats: mockFetchUserStats,
+}));
+
+import UserStatsCard from "@/features/account/components/UserStatsCard";
+
+function renderCard() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <UserStatsCard />
+    </ChakraProvider>,
+  );
+}
+
+describe("UserStatsCard – loading state", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Your Activity' heading immediately (before fetch resolves)", () => {
+    mockFetchUserStats.mockReturnValueOnce(new Promise(() => {}));
+    renderCard();
+    expect(screen.getByText("Your Activity")).toBeInTheDocument();
+  });
+});
+
+describe("UserStatsCard – stats loaded with factions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows faction name and 'matches' (plural) when count > 1", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 2,
+      matchesPlayed: 5,
+      wins: 3,
+      losses: 2,
+      factions: [{ name: "Greenskins", count: 3 }],
+    });
+    renderCard();
+    await waitFor(() => expect(screen.getByText("Greenskins")).toBeInTheDocument());
+    expect(screen.getByText(/3 matches/)).toBeInTheDocument();
+  });
+
+  it("shows 'match' (singular) when faction count === 1", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 1,
+      matchesPlayed: 1,
+      wins: 1,
+      losses: 0,
+      factions: [{ name: "Empire", count: 1 }],
+    });
+    renderCard();
+    await waitFor(() => expect(screen.getByText("Empire")).toBeInTheDocument());
+    expect(screen.getByText(/1 match\b/)).toBeInTheDocument();
+  });
+});
+
+describe("UserStatsCard – no factions (empty array)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("hides faction section when factions array is empty", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 2,
+      matchesPlayed: 4,
+      wins: 2,
+      losses: 2,
+      factions: [],
+    });
+    renderCard();
+    await waitFor(() =>
+      expect(screen.queryByText(/factions played/i)).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("UserStatsCard – no activity message", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'No activity recorded yet' when matchesPlayed=0 and tournamentsCreated=0", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 0,
+      matchesPlayed: 0,
+      wins: 0,
+      losses: 0,
+      factions: [],
+    });
+    renderCard();
+    await waitFor(() =>
+      expect(screen.getByText(/no activity recorded yet/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("does not show 'No activity' when user has tournaments created", async () => {
+    mockFetchUserStats.mockResolvedValueOnce({
+      tournamentsCreated: 1,
+      matchesPlayed: 0,
+      wins: 0,
+      losses: 0,
+      factions: [],
+    });
+    renderCard();
+    await waitFor(() =>
+      // Stats card should show but no "no activity" message
+      expect(screen.queryByText(/no activity recorded yet/i)).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("UserStatsCard – fetchUserStats returns null", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows no stats values when fetchUserStats returns null", async () => {
+    mockFetchUserStats.mockResolvedValueOnce(null);
+    renderCard();
+    // Stat values should default to 0 (via ??)
+    await waitFor(() => {
+      const zeros = screen.getAllByText("0");
+      expect(zeros.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/client-app/src/tests/features/account/UsernameUpdateForm.test.tsx
+++ b/client-app/src/tests/features/account/UsernameUpdateForm.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Branch coverage for account/components/UsernameUpdateForm.tsx:
+ * - user.username || "" → initial input value (empty when no username)
+ * - validation: !username || username.length < 3 → shows error message
+ * - isGuest=true → calls updateGuestUsername
+ * - isGuest=false → calls updateAuthUsername
+ * - catch: error instanceof Error → shows error.message
+ * - catch: error NOT instanceof Error → shows "Failed to update username"
+ * - handleUsernameChange: if (error) setError("") → clears error on re-type
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const {
+  mockUpdateGuestUsername,
+  mockUpdateAuthUsername,
+  mockUseUserStore,
+} = vi.hoisted(() => ({
+  mockUpdateGuestUsername: vi.fn(),
+  mockUpdateAuthUsername: vi.fn(),
+  mockUseUserStore: vi.fn(),
+}));
+
+vi.mock("@/features/authentication/api/guestApi", () => ({
+  updateGuestUsername: mockUpdateGuestUsername,
+}));
+
+vi.mock("@/features/account/api/accountApi", () => ({
+  updateUsername: mockUpdateAuthUsername,
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: (selector: (state: any) => any) => mockUseUserStore(selector),
+}));
+
+import UsernameUpdateForm from "@/features/account/components/UsernameUpdateForm";
+
+function setupStore(username = "Grimgork") {
+  mockUseUserStore.mockImplementation((selector: (state: any) => any) =>
+    selector({ user: { username } }),
+  );
+}
+
+function renderForm(username = "Grimgork", isGuest = false) {
+  setupStore(username);
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <UsernameUpdateForm isGuest={isGuest} />
+    </ChakraProvider>,
+  );
+}
+
+describe("UsernameUpdateForm – initial value (user.username || '')", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("initialises input with user.username when set", () => {
+    renderForm("Grimgork");
+    expect(screen.getByPlaceholderText(/new username/i)).toHaveValue("Grimgork");
+  });
+
+  it("initialises input as empty string when user.username is falsy", () => {
+    renderForm("");
+    expect(screen.getByPlaceholderText(/new username/i)).toHaveValue("");
+  });
+});
+
+describe("UsernameUpdateForm – validation error (!username || length < 3)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows error when username is empty on submit", async () => {
+    renderForm("");
+    fireEvent.submit(screen.getByRole("button", { name: /update username/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/usernames must be at least 3 characters/i),
+      ).toBeInTheDocument(),
+    );
+    expect(mockUpdateAuthUsername).not.toHaveBeenCalled();
+  });
+
+  it("shows error when username is shorter than 3 chars", async () => {
+    renderForm("");
+    fireEvent.change(screen.getByPlaceholderText(/new username/i), {
+      target: { value: "ab" },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /update username/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/usernames must be at least 3 characters/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("UsernameUpdateForm – clears error on re-type (if error setError(''))", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clears validation error when user types again", async () => {
+    renderForm("");
+    fireEvent.submit(screen.getByRole("button", { name: /update username/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/usernames must be at least 3 characters/i),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByPlaceholderText(/new username/i), {
+      target: { value: "NewName" },
+    });
+    expect(
+      screen.queryByText(/usernames must be at least 3 characters/i),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("UsernameUpdateForm – isGuest branch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls updateGuestUsername when isGuest=true", async () => {
+    mockUpdateGuestUsername.mockResolvedValueOnce({ success: true });
+    renderForm("Grimgork", true);
+    fireEvent.submit(screen.getByRole("button", { name: /update username/i }));
+    await waitFor(() => expect(mockUpdateGuestUsername).toHaveBeenCalledWith("Grimgork"));
+    expect(mockUpdateAuthUsername).not.toHaveBeenCalled();
+  });
+
+  it("calls updateUsername (auth) when isGuest=false", async () => {
+    mockUpdateAuthUsername.mockResolvedValueOnce({ success: true });
+    renderForm("Grimgork", false);
+    fireEvent.submit(screen.getByRole("button", { name: /update username/i }));
+    await waitFor(() => expect(mockUpdateAuthUsername).toHaveBeenCalledWith("Grimgork"));
+    expect(mockUpdateGuestUsername).not.toHaveBeenCalled();
+  });
+});
+
+describe("UsernameUpdateForm – catch Error instanceof branches", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows error.message when caught error is an Error instance", async () => {
+    mockUpdateAuthUsername.mockRejectedValueOnce(new Error("Username taken"));
+    renderForm("Grimgork", false);
+    fireEvent.submit(screen.getByRole("button", { name: /update username/i }));
+    await waitFor(() =>
+      expect(screen.getByText("Username taken")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows generic message when caught error is not an Error instance", async () => {
+    mockUpdateAuthUsername.mockRejectedValueOnce("some string error");
+    renderForm("Grimgork", false);
+    fireEvent.submit(screen.getByRole("button", { name: /update username/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/failed to update username/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/client-app/src/tests/features/authentication/RegisterLogin.test.tsx
+++ b/client-app/src/tests/features/authentication/RegisterLogin.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Branch coverage for authentication/components/RegisterLogin.tsx:
+ * - Button click → opens drawer (handleClick → drawer.open)
+ * - auth-event "close-drawer" → drawer.close called
+ * - auth-event "open-drawer" → handleClick called (drawer.open)
+ * - title && (...) → Drawer header shown with title
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+vi.mock("@/features/authentication/components/AuthenticationForm", () => ({
+  AuthenticationForm: () => <div data-testid="auth-form" />,
+}));
+
+import { RegisterLogin } from "@/features/authentication/components/RegisterLogin";
+
+function renderRegisterLogin() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <RegisterLogin />
+    </ChakraProvider>,
+  );
+}
+
+describe("RegisterLogin – initial render", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders Register/Login button", () => {
+    renderRegisterLogin();
+    expect(
+      screen.getByRole("button", { name: /register\/login/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("RegisterLogin – button click opens drawer", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows drawer with 'Authentication' title after clicking button", async () => {
+    renderRegisterLogin();
+    fireEvent.click(screen.getByRole("button", { name: /register\/login/i }));
+    await waitFor(() =>
+      expect(screen.getByText("Authentication")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("auth-form")).toBeInTheDocument();
+  });
+});
+
+describe("RegisterLogin – auth-event open-drawer", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("opens drawer when auth-event with type='open-drawer' is dispatched", async () => {
+    renderRegisterLogin();
+    const event = new CustomEvent("auth-event", {
+      detail: { type: "open-drawer" },
+    });
+    document.dispatchEvent(event);
+    await waitFor(() =>
+      expect(screen.getByText("Authentication")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("RegisterLogin – auth-event close-drawer", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("closes drawer when auth-event with type='close-drawer' is dispatched after open", async () => {
+    renderRegisterLogin();
+    // Open the drawer first
+    fireEvent.click(screen.getByRole("button", { name: /register\/login/i }));
+    await waitFor(() =>
+      expect(screen.getByText("Authentication")).toBeInTheDocument(),
+    );
+    // Now close via auth-event
+    const closeEvent = new CustomEvent("auth-event", {
+      detail: { type: "close-drawer" },
+    });
+    document.dispatchEvent(closeEvent);
+    await waitFor(() =>
+      expect(screen.queryByText("Authentication")).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/client-app/src/tests/features/matches/MatchCard.test.tsx
+++ b/client-app/src/tests/features/matches/MatchCard.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * Branch coverage for matches/components/MatchCard.tsx:
+ * - m.status === "pending" → "Pending" badge
+ * - m.status === "in_progress" → "In Progress" badge
+ * - m.status === "completed" → "Completed" badge
+ * - m.status === "disputed" → "⚠ Disputed" badge
+ * - p1Won → W badge on player1
+ * - m.winnerId && !p1Won → L badge on player1
+ * - p2Won → W badge on player2
+ * - m.winnerId && !p2Won && player2 !== "BYE" → L badge on player2
+ * - player2.name === "BYE" → no L badge
+ * - resultOverrides.length > 0 → "Overridden" button shown
+ * - resultOverrides.length > 1 → "2×" count prefix
+ * - m.winnerId → Winner section shown
+ * - canParticipantReport + no myReport → "Who won this match?"
+ * - canParticipantReport + myReport → "Change your reported winner:"
+ * - isOverriding → override panel, Cancel/Confirm buttons
+ * - isOverriding + resultOverrides.length===1 → "overridden once" message
+ * - isAdmin && isActive && status !== completed/disputed → record result buttons
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import MatchCard from "@/features/matches/components/MatchCard";
+
+const baseMatch = {
+  _id: "m1",
+  round: 1,
+  matchNumber: 1,
+  player1: { participantId: "p1", name: "Grimgork", faction: "Greenskins" },
+  player2: { participantId: "p2", name: "Luthor", faction: "Empire" },
+  winnerId: null as string | null,
+  loserId: null as string | null,
+  status: "pending" as "pending" | "in_progress" | "completed" | "disputed",
+  notes: "",
+  reportedResults: [] as {
+    reportedBy: string;
+    reportedByName: string;
+    winnerId: string;
+  }[],
+  resultOverrides: [] as {
+    previousWinnerId: string | null;
+    newWinnerId: string;
+    overriddenBy: string;
+    reason: string;
+    overriddenAt: string;
+  }[],
+  completedAt: null as string | null,
+  bracketSide: null as "winners" | "losers" | "grand_final" | null,
+};
+
+const baseFns = {
+  onRecordResult: vi.fn(),
+  onReportResult: vi.fn(),
+  onResolveDispute: vi.fn(),
+  onStartOverride: vi.fn(),
+  onCancelOverride: vi.fn(),
+  onSetOverrideWinner: vi.fn(),
+  onSetOverrideReason: vi.fn(),
+  onConfirmOverride: vi.fn(),
+};
+
+function renderCard(
+  matchOverride: Partial<typeof baseMatch> = {},
+  extraProps: Record<string, unknown> = {},
+) {
+  const m = { ...baseMatch, ...matchOverride };
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <MatchCard
+        m={m}
+        p1Won={false}
+        p2Won={false}
+        isOverriding={false}
+        isAdmin={false}
+        isActive={false}
+        myReport={undefined}
+        canParticipantReport={false}
+        isP1={false}
+        isP2={false}
+        actionLoading={false}
+        overrideLoading={false}
+        overrideWinnerId=""
+        overrideReason=""
+        borderColor="border"
+        mutedBg="bg.subtle"
+        {...baseFns}
+        {...extraProps}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("MatchCard – status badges", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Pending' badge for status=pending", () => {
+    renderCard({ status: "pending" });
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("shows 'In Progress' badge for status=in_progress", () => {
+    renderCard({ status: "in_progress" });
+    expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Completed' badge for status=completed", () => {
+    renderCard({ status: "completed" });
+    expect(screen.getByText(/completed/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Disputed' badge for status=disputed", () => {
+    renderCard({ status: "disputed" });
+    expect(screen.getByText(/disputed/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – W/L badges", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows W badge when p1Won=true", () => {
+    renderCard(
+      { status: "completed", winnerId: "p1" },
+      { p1Won: true, p2Won: false },
+    );
+    const wBadges = screen.getAllByText("W");
+    expect(wBadges.length).toBeGreaterThan(0);
+  });
+
+  it("shows L badge on player1 when winnerId is set and !p1Won", () => {
+    renderCard(
+      { status: "completed", winnerId: "p2" },
+      { p1Won: false, p2Won: true },
+    );
+    expect(screen.getByText("L")).toBeInTheDocument();
+  });
+
+  it("shows W badge when p2Won=true", () => {
+    renderCard(
+      { status: "completed", winnerId: "p2" },
+      { p1Won: false, p2Won: true },
+    );
+    const wBadges = screen.getAllByText("W");
+    expect(wBadges.length).toBeGreaterThan(0);
+  });
+
+  it("does not show L badge for player2 when player2 is BYE", () => {
+    renderCard(
+      {
+        status: "completed",
+        winnerId: "p1",
+        player2: { participantId: "bye", name: "BYE", faction: "" },
+      },
+      { p1Won: true, p2Won: false },
+    );
+    expect(screen.queryByText("L")).not.toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – resultOverrides button", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Overridden' trigger when resultOverrides.length > 0", () => {
+    renderCard({
+      resultOverrides: [
+        {
+          previousWinnerId: null,
+          newWinnerId: "p1",
+          overriddenBy: "admin1",
+          reason: "cheating",
+          overriddenAt: new Date().toISOString(),
+        },
+      ],
+    });
+    expect(screen.getByText(/overridden/i)).toBeInTheDocument();
+  });
+
+  it("shows '2×' count prefix when resultOverrides.length > 1", () => {
+    renderCard({
+      resultOverrides: [
+        {
+          previousWinnerId: null,
+          newWinnerId: "p1",
+          overriddenBy: "admin1",
+          reason: "",
+          overriddenAt: new Date().toISOString(),
+        },
+        {
+          previousWinnerId: "p1",
+          newWinnerId: "p2",
+          overriddenBy: "admin1",
+          reason: "",
+          overriddenAt: new Date().toISOString(),
+        },
+      ],
+    });
+    expect(screen.getByText(/2×/)).toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – Winner section", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows Winner section when m.winnerId is set", () => {
+    renderCard({ winnerId: "p1", status: "completed" });
+    expect(screen.getByText(/winner:/i)).toBeInTheDocument();
+  });
+
+  it("does not show Winner section when m.winnerId is null", () => {
+    renderCard({ winnerId: null });
+    expect(screen.queryByText(/winner:/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – canParticipantReport (myReport branch)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Who won this match?' when no myReport", () => {
+    renderCard(
+      { status: "in_progress" },
+      { canParticipantReport: true, myReport: undefined },
+    );
+    expect(screen.getByText(/who won this match/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Change your reported winner:' when myReport is present", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        canParticipantReport: true,
+        myReport: {
+          reportedBy: "u1",
+          reportedByName: "User",
+          winnerId: "p1",
+        },
+      },
+    );
+    expect(screen.getByText(/change your reported winner/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – isOverriding panel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows override panel with Confirm Override button", () => {
+    renderCard({}, { isOverriding: true });
+    expect(screen.getByText(/override result/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /confirm override/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onCancelOverride when Cancel is clicked", () => {
+    const onCancelOverride = vi.fn();
+    renderCard({}, { isOverriding: true, onCancelOverride });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancelOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows 'overridden once' message when resultOverrides.length === 1", () => {
+    renderCard(
+      {
+        resultOverrides: [
+          {
+            previousWinnerId: null,
+            newWinnerId: "p1",
+            overriddenBy: "admin1",
+            reason: "",
+            overriddenAt: new Date().toISOString(),
+          },
+        ],
+      },
+      { isOverriding: true },
+    );
+    expect(screen.getByText(/overridden once/i)).toBeInTheDocument();
+  });
+
+  it("shows 'N times' message when resultOverrides.length > 1", () => {
+    renderCard(
+      {
+        resultOverrides: [
+          {
+            previousWinnerId: null,
+            newWinnerId: "p1",
+            overriddenBy: "admin1",
+            reason: "",
+            overriddenAt: new Date().toISOString(),
+          },
+          {
+            previousWinnerId: "p1",
+            newWinnerId: "p2",
+            overriddenBy: "admin1",
+            reason: "",
+            overriddenAt: new Date().toISOString(),
+          },
+        ],
+      },
+      { isOverriding: true },
+    );
+    expect(screen.getByText(/2 times/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchCard – admin record-result buttons", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Record result' section for admin (not p1/p2, status=pending, player2 not BYE)", () => {
+    renderCard(
+      { status: "pending" },
+      { isAdmin: true, isActive: true, isP1: false, isP2: false },
+    );
+    expect(screen.getByText(/record result/i)).toBeInTheDocument();
+  });
+
+  it("calls onRecordResult when admin clicks player1 wins", () => {
+    const onRecordResult = vi.fn();
+    renderCard(
+      { status: "pending" },
+      { isAdmin: true, isActive: true, isP1: false, isP2: false, onRecordResult },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /grimgork wins/i }));
+    expect(onRecordResult).toHaveBeenCalledWith("m1", "p1");
+  });
+});

--- a/client-app/src/tests/features/matches/MatchesSection.test.tsx
+++ b/client-app/src/tests/features/matches/MatchesSection.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Branch coverage for matches/components/MatchesSection.tsx:
+ * - matches.length === 0 → "No Matches Generated Yet"
+ * - isDoubleElim → Winners Bracket / Losers Bracket / Grand Final sections
+ * - gfMatches.length > 1 → "Bracket Reset" badge
+ * - isRoundRobin → "Round Robin" badge + standings table
+ * - isSwiss → "Swiss System" badge + standings table
+ * - isCurrentRound && !isRROrSwiss → "Current" badge
+ * - !isCurrentRound && round < maxRound && !isRROrSwiss → "Completed" badge
+ * - isAdmin && isActive && matches.length > 0 → footer with Advance Round
+ * - isRoundRobin footer → "Finalize Tournament" text
+ * - !isDoubleElim badge: "Round X of Y"
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import MatchesSection from "@/features/matches/components/MatchesSection";
+
+vi.mock("@/features/matches/components/MatchCard", () => ({
+  default: ({ m }: { m: { matchNumber: number } }) => (
+    <div data-testid={`match-card-${m.matchNumber}`} />
+  ),
+}));
+
+type MatchStatus = "pending" | "in_progress" | "completed" | "disputed";
+type BracketSide = "winners" | "losers" | "grand_final" | null;
+
+function makeMatch(overrides: Partial<{
+  _id: string;
+  round: number;
+  matchNumber: number;
+  status: MatchStatus;
+  winnerId: string | null;
+  bracketSide: BracketSide;
+}> = {}) {
+  return {
+    _id: overrides._id ?? "m1",
+    round: overrides.round ?? 1,
+    matchNumber: overrides.matchNumber ?? 1,
+    player1: { participantId: "p1", name: "Grimgork", faction: "Greenskins" },
+    player2: { participantId: "p2", name: "Luthor", faction: "Empire" },
+    winnerId: overrides.winnerId ?? null,
+    loserId: null,
+    status: overrides.status ?? "pending",
+    notes: "",
+    reportedResults: [],
+    resultOverrides: [],
+    completedAt: null,
+    bracketSide: overrides.bracketSide ?? null,
+  };
+}
+
+function makeTournament(tournamentType = "Single Elimination") {
+  return {
+    _id: "t1",
+    name: "Test Tournament",
+    code: "CODE",
+    description: "",
+    playerCount: 2,
+    tournamentType,
+    bannedFactions: [],
+    enable40kFactions: false,
+    participants: [
+      { _id: "p1", name: "Grimgork", faction: "Greenskins" },
+      { _id: "p2", name: "Luthor", faction: "Empire" },
+    ],
+    status: "active" as const,
+    createdAt: new Date().toISOString(),
+    createdBy: "admin",
+  };
+}
+
+const baseProps = {
+  user: null,
+  isAdmin: false,
+  isActive: true,
+  actionLoading: false,
+  matchLoading: false,
+  onRecordResult: vi.fn(),
+  onReportResult: vi.fn(),
+  onOverrideResult: vi.fn().mockResolvedValue(undefined),
+  onResolveDispute: vi.fn(),
+  onAdvanceRound: vi.fn(),
+};
+
+function renderSection(
+  matches: ReturnType<typeof makeMatch>[],
+  tournament = makeTournament(),
+  props: Partial<typeof baseProps> = {},
+) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <MatchesSection
+        matches={matches as any}
+        selected={tournament as any}
+        {...baseProps}
+        {...props}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("MatchesSection – empty matches", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'No Matches Generated Yet' when matches array is empty", () => {
+    renderSection([]);
+    expect(screen.getByText(/no matches generated yet/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchesSection – Single Elimination badges", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Round X of Y' badge for single elim with matches", () => {
+    renderSection([makeMatch({ round: 1 })]);
+    expect(screen.getByText(/round 1 of 1/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Current' badge for the highest round when isActive", () => {
+    renderSection(
+      [
+        makeMatch({ _id: "m1", round: 1, matchNumber: 1, status: "completed", winnerId: "p1" }),
+        makeMatch({ _id: "m2", round: 2, matchNumber: 2, status: "pending" }),
+      ],
+      makeTournament("Single Elimination"),
+      { isActive: true },
+    );
+    expect(screen.getByText("Current")).toBeInTheDocument();
+  });
+
+  it("shows 'Completed' badge for rounds before the max round", () => {
+    renderSection(
+      [
+        makeMatch({ _id: "m1", round: 1, matchNumber: 1, status: "completed", winnerId: "p1" }),
+        makeMatch({ _id: "m2", round: 2, matchNumber: 2, status: "pending" }),
+      ],
+      makeTournament("Single Elimination"),
+      { isActive: true },
+    );
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+  });
+});
+
+describe("MatchesSection – Round Robin", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Round Robin' badge for Round Robin tournament", () => {
+    renderSection([makeMatch({ round: 1 })], makeTournament("Round Robin"));
+    expect(screen.getByText("Round Robin")).toBeInTheDocument();
+  });
+
+  it("shows standings table for Round Robin with completed matches", () => {
+    renderSection(
+      [
+        makeMatch({
+          _id: "m1",
+          round: 1,
+          status: "completed",
+          winnerId: "p1",
+          bracketSide: null,
+        }),
+      ],
+      makeTournament("Round Robin"),
+    );
+    expect(screen.getByText("Standings")).toBeInTheDocument();
+  });
+});
+
+describe("MatchesSection – Swiss System", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Swiss System' badge", () => {
+    renderSection([makeMatch({ round: 1 })], makeTournament("Swiss System"));
+    expect(screen.getByText("Swiss System")).toBeInTheDocument();
+  });
+});
+
+describe("MatchesSection – Double Elimination", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Double Elimination' badge", () => {
+    renderSection(
+      [makeMatch({ _id: "m1", round: 1, bracketSide: "winners" })],
+      makeTournament("Double Elimination"),
+    );
+    expect(screen.getByText("Double Elimination")).toBeInTheDocument();
+  });
+
+  it("shows Winners Bracket section", () => {
+    renderSection(
+      [makeMatch({ _id: "m1", round: 1, bracketSide: "winners" })],
+      makeTournament("Double Elimination"),
+    );
+    expect(screen.getByText(/winners bracket/i)).toBeInTheDocument();
+  });
+
+  it("shows Losers Bracket section when losers matches exist", () => {
+    renderSection(
+      [
+        makeMatch({ _id: "m1", round: 1, matchNumber: 1, bracketSide: "winners" }),
+        makeMatch({ _id: "m2", round: 1, matchNumber: 2, bracketSide: "losers" }),
+      ],
+      makeTournament("Double Elimination"),
+    );
+    expect(screen.getByText(/losers bracket/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Grand Final' section when grand_final matches exist", () => {
+    renderSection(
+      [
+        makeMatch({ _id: "m1", round: 1, matchNumber: 1, bracketSide: "winners" }),
+        makeMatch({ _id: "m2", round: 99, matchNumber: 2, bracketSide: "grand_final" }),
+      ],
+      makeTournament("Double Elimination"),
+    );
+    expect(screen.getByText(/grand final/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Bracket Reset' badge when gfMatches.length > 1", () => {
+    renderSection(
+      [
+        makeMatch({ _id: "m1", round: 1, matchNumber: 1, bracketSide: "winners" }),
+        makeMatch({ _id: "m2", round: 99, matchNumber: 2, bracketSide: "grand_final" }),
+        makeMatch({ _id: "m3", round: 100, matchNumber: 3, bracketSide: "grand_final" }),
+      ],
+      makeTournament("Double Elimination"),
+    );
+    expect(screen.getByText(/bracket reset/i)).toBeInTheDocument();
+  });
+});
+
+describe("MatchesSection – admin footer", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows footer with 'Advance Round' when isAdmin && isActive && matches.length > 0", () => {
+    renderSection([makeMatch()], makeTournament(), { isAdmin: true, isActive: true });
+    expect(screen.getByRole("button", { name: /advance round/i })).toBeInTheDocument();
+  });
+
+  it("shows 'Finalize Tournament' button for Round Robin", () => {
+    renderSection(
+      [makeMatch()],
+      makeTournament("Round Robin"),
+      { isAdmin: true, isActive: true },
+    );
+    expect(
+      screen.getByRole("button", { name: /finalize tournament/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show footer when isAdmin=false", () => {
+    renderSection([makeMatch()], makeTournament(), { isAdmin: false, isActive: true });
+    expect(
+      screen.queryByRole("button", { name: /advance round/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onAdvanceRound when Advance Round button is clicked", () => {
+    const onAdvanceRound = vi.fn();
+    renderSection([makeMatch()], makeTournament(), {
+      isAdmin: true,
+      isActive: true,
+      onAdvanceRound,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /advance round/i }));
+    expect(onAdvanceRound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client-app/src/tests/features/statistics/StatisticsPage.test.tsx
+++ b/client-app/src/tests/features/statistics/StatisticsPage.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * Branch coverage for statistics/components/StatisticsPage.tsx:
+ * - loading=true → Spinner + "Loading statistics…"
+ * - error (Error instance) → shows error.message
+ * - error (non-Error) → shows "Failed to load statistics"
+ * - stats=null from fetch (res.data = null equivalent) → still renders after loading
+ * - stats.cachedAt present → shows "Updated" timestamp
+ * - stats.topFactions.length === 0 → "No faction data yet."
+ * - stats.topFactions.length > 0 → faction list with bars
+ * - f.wins === 1 → "win" (singular)
+ * - f.wins > 1 → "wins" (plural)
+ * - stats.topPlayers.length === 0 → "No player data yet."
+ * - p.factions.filter(Boolean).length > 0 → shows faction subtext
+ * - stats.recentWinners.length === 0 → "No tournaments completed..."
+ * - w.winnerFaction present → shows faction badge
+ * - stats.topCreators.length === 0 → "No data yet."
+ * - c.completed > 0 → shows "done" badge
+ * - stats.recentTournaments.length > 0 → Recent Completed Tournaments section
+ * - StatCard: colorPalette === "ink" → bg.subtle icon bg
+ * - StatCard: sub present → sub text rendered
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { get: mockGet },
+}));
+
+import StatisticsPage from "@/features/statistics/components/StatisticsPage";
+
+const baseStats = {
+  cachedAt: undefined as string | undefined,
+  tournaments: { pending: 0, active: 0, completed: 0, total: 0 },
+  matches: {
+    pending: 0,
+    in_progress: 0,
+    completed: 0,
+    disputed: 0,
+    total: 0,
+    completionRate: 0,
+  },
+  topPlayers: [] as any[],
+  topFactions: [] as any[],
+  topCreators: [] as any[],
+  recentTournaments: [] as any[],
+  recentWinners: [] as any[],
+};
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <StatisticsPage />
+    </ChakraProvider>,
+  );
+}
+
+describe("StatisticsPage – loading state", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows spinner and 'Loading statistics…' while fetch is in flight", () => {
+    mockGet.mockReturnValueOnce(new Promise(() => {}));
+    renderPage();
+    expect(screen.getByText(/loading statistics/i)).toBeInTheDocument();
+  });
+});
+
+describe("StatisticsPage – error states", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows error.message when fetch throws an Error instance", async () => {
+    mockGet.mockRejectedValueOnce(new Error("Network failure"));
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Network failure")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'Failed to load statistics' when fetch throws non-Error", async () => {
+    mockGet.mockRejectedValueOnce("string error");
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load statistics/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("StatisticsPage – empty sections", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'No faction data yet.' when topFactions is empty", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: { ...baseStats, topFactions: [] },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/no faction data yet/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'No player data yet.' when topPlayers is empty", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: { ...baseStats, topPlayers: [] },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/no player data yet/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'No tournaments completed...' when recentWinners is empty", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: { ...baseStats, recentWinners: [] },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/no tournaments completed in the last 7 days/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'No data yet.' when topCreators is empty", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: { ...baseStats, topCreators: [] },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/no data yet/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("StatisticsPage – topFactions with data", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows faction name and 'wins' (plural) when wins > 1", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseStats,
+        topFactions: [{ faction: "Greenskins", wins: 5 }],
+      },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Greenskins")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/5 wins/)).toBeInTheDocument();
+  });
+
+  it("shows 'win' (singular) when wins === 1", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseStats,
+        topFactions: [{ faction: "Empire", wins: 1 }],
+      },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/1 win\b/)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("StatisticsPage – topPlayers with factions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows player faction subtext when factions array is non-empty", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseStats,
+        topPlayers: [{ name: "Grimgork", wins: 3, factions: ["Greenskins"] }],
+      },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Grimgork")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Greenskins")).toBeInTheDocument();
+  });
+
+  it("hides faction subtext when player factions array is empty", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseStats,
+        topPlayers: [{ name: "Luthor", wins: 2, factions: [] }],
+      },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Luthor")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("StatisticsPage – topCreators 'done' badge (c.completed > 0)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'done' badge when c.completed > 0", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseStats,
+        topCreators: [
+          { username: "Admin", tournamentsCreated: 3, completed: 2 },
+        ],
+      },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Admin")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/2 done/)).toBeInTheDocument();
+  });
+
+  it("hides 'done' badge when c.completed === 0", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseStats,
+        topCreators: [
+          { username: "Admin", tournamentsCreated: 1, completed: 0 },
+        ],
+      },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Admin")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/done/)).not.toBeInTheDocument();
+  });
+});
+
+describe("StatisticsPage – recentTournaments section", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows Recent Completed Tournaments section when recentTournaments.length > 0", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseStats,
+        recentTournaments: [
+          {
+            _id: "t1",
+            name: "Winter Cup",
+            tournamentType: "Single Elimination",
+            participants: [],
+            playerCount: 8,
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText("Winter Cup")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/recent completed tournaments/i)).toBeInTheDocument();
+  });
+});
+
+describe("StatisticsPage – cachedAt timestamp", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Updated' text when stats.cachedAt is set", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...baseStats,
+        cachedAt: "2024-01-15T10:30:00.000Z",
+      },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/updated/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/client-app/src/tests/shared/ui/ColorMode.test.tsx
+++ b/client-app/src/tests/shared/ui/ColorMode.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Branch coverage for shared/ui/ColorMode.tsx:
+ * - toggleColorMode: resolvedTheme === "dark" → setTheme("light")
+ * - toggleColorMode: resolvedTheme !== "dark" → setTheme("dark")
+ * - useColorModeValue: colorMode === "dark" → returns dark value
+ * - useColorModeValue: colorMode !== "dark" → returns light value
+ * - ColorModeIcon: colorMode === "dark" → renders LuMoon
+ * - ColorModeIcon: colorMode !== "dark" → renders LuSun
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, renderHook, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const { mockUseTheme } = vi.hoisted(() => ({
+  mockUseTheme: vi.fn(),
+}));
+
+vi.mock("next-themes", () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTheme: mockUseTheme,
+}));
+
+vi.mock("react-icons/lu", () => ({
+  LuMoon: () => <span data-testid="icon-moon" />,
+  LuSun: () => <span data-testid="icon-sun" />,
+  LuEye: () => null,
+  LuEyeOff: () => null,
+}));
+
+import {
+  useColorMode,
+  useColorModeValue,
+  ColorModeIcon,
+  ColorModeButton,
+} from "@/shared/ui/ColorMode";
+
+describe("useColorMode – toggleColorMode branch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls setTheme('light') when resolvedTheme is 'dark'", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+    });
+    const { result } = renderHook(() => useColorMode());
+    act(() => result.current.toggleColorMode());
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("calls setTheme('dark') when resolvedTheme is 'light'", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "light",
+      setTheme: mockSetTheme,
+    });
+    const { result } = renderHook(() => useColorMode());
+    act(() => result.current.toggleColorMode());
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("exposes colorMode and setColorMode from useTheme", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+    });
+    const { result } = renderHook(() => useColorMode());
+    expect(result.current.colorMode).toBe("dark");
+    expect(result.current.setColorMode).toBe(mockSetTheme);
+  });
+});
+
+describe("useColorModeValue – dark vs light branch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the light value when colorMode is 'light'", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light", setTheme: vi.fn() });
+    const { result } = renderHook(() =>
+      useColorModeValue("light-value", "dark-value"),
+    );
+    expect(result.current).toBe("light-value");
+  });
+
+  it("returns the dark value when colorMode is 'dark'", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "dark", setTheme: vi.fn() });
+    const { result } = renderHook(() =>
+      useColorModeValue("light-value", "dark-value"),
+    );
+    expect(result.current).toBe("dark-value");
+  });
+});
+
+describe("ColorModeIcon – moon vs sun", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders LuMoon when colorMode is 'dark'", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "dark", setTheme: vi.fn() });
+    render(<ColorModeIcon />);
+    expect(screen.getByTestId("icon-moon")).toBeInTheDocument();
+    expect(screen.queryByTestId("icon-sun")).not.toBeInTheDocument();
+  });
+
+  it("renders LuSun when colorMode is 'light'", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light", setTheme: vi.fn() });
+    render(<ColorModeIcon />);
+    expect(screen.getByTestId("icon-sun")).toBeInTheDocument();
+    expect(screen.queryByTestId("icon-moon")).not.toBeInTheDocument();
+  });
+});
+
+describe("ColorModeButton – click triggers toggleColorMode", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls setTheme('light') when clicked in dark mode", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+    });
+    render(
+      <ChakraProvider value={defaultSystem}>
+        <ColorModeButton />
+      </ChakraProvider>,
+    );
+    const btn = screen.getByRole("button", { name: /toggle color mode/i });
+    fireEvent.click(btn);
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("calls setTheme('dark') when clicked in light mode", () => {
+    const mockSetTheme = vi.fn();
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "light",
+      setTheme: mockSetTheme,
+    });
+    render(
+      <ChakraProvider value={defaultSystem}>
+        <ColorModeButton />
+      </ChakraProvider>,
+    );
+    const btn = screen.getByRole("button", { name: /toggle color mode/i });
+    fireEvent.click(btn);
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+});

--- a/client-app/src/tests/shared/ui/PasswordInput.test.tsx
+++ b/client-app/src/tests/shared/ui/PasswordInput.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Branch coverage for shared/ui/PasswordInput.tsx:
+ * PasswordInput:
+ *   - visible=false (default) → type="password", shows LuEye icon
+ *   - after toggle → type="text", shows LuEyeOff icon
+ *   - onPointerDown disabled guard: rest.disabled=true → no toggle
+ *   - onPointerDown button guard: e.button !== 0 → no toggle
+ * PasswordStrengthMeter (getColorPalette):
+ *   - percent < 33 → "Low" label
+ *   - percent < 66 → "Medium" label
+ *   - default (percent >= 66) → "High" label
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { PasswordInput, PasswordStrengthMeter } from "@/shared/ui/PasswordInput";
+
+function renderPasswordInput(props: React.ComponentProps<typeof PasswordInput> = {}) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PasswordInput placeholder="password" data-testid="pwd-input" {...props} />
+    </ChakraProvider>,
+  );
+}
+
+describe("PasswordInput – initial type", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders as type='password' by default", () => {
+    const { container } = renderPasswordInput();
+    const input = container.querySelector("input");
+    expect(input).toHaveAttribute("type", "password");
+  });
+});
+
+describe("PasswordInput – toggle visibility", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("switches to type='text' after clicking the toggle button", () => {
+    const { container } = renderPasswordInput();
+    const toggleBtn = screen.getByRole("button", {
+      name: /toggle password visibility/i,
+    });
+    fireEvent.pointerDown(toggleBtn, { button: 0 });
+    expect(container.querySelector("input")).toHaveAttribute("type", "text");
+  });
+
+  it("switches back to type='password' after clicking toggle twice", () => {
+    const { container } = renderPasswordInput();
+    const toggleBtn = screen.getByRole("button", {
+      name: /toggle password visibility/i,
+    });
+    fireEvent.pointerDown(toggleBtn, { button: 0 });
+    fireEvent.pointerDown(toggleBtn, { button: 0 });
+    expect(container.querySelector("input")).toHaveAttribute("type", "password");
+  });
+});
+
+describe("PasswordInput – onPointerDown guards", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not toggle when disabled prop is true", () => {
+    const { container } = renderPasswordInput({ disabled: true });
+    const toggleBtn = screen.getByRole("button", {
+      name: /toggle password visibility/i,
+    });
+    fireEvent.pointerDown(toggleBtn, { button: 0 });
+    expect(container.querySelector("input")).toHaveAttribute("type", "password");
+  });
+
+  it("does not toggle when pointer button is not 0 (non-left-click)", () => {
+    const { container } = renderPasswordInput();
+    const toggleBtn = screen.getByRole("button", {
+      name: /toggle password visibility/i,
+    });
+    fireEvent.pointerDown(toggleBtn, { button: 1 });
+    expect(container.querySelector("input")).toHaveAttribute("type", "password");
+  });
+});
+
+describe("PasswordInput – defaultVisible prop", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders as type='text' when defaultVisible=true", () => {
+    const { container } = renderPasswordInput({ defaultVisible: true });
+    expect(container.querySelector("input")).toHaveAttribute("type", "text");
+  });
+});
+
+function renderMeter(value: number, max = 4) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <PasswordStrengthMeter value={value} max={max} />
+    </ChakraProvider>,
+  );
+}
+
+describe("PasswordStrengthMeter – getColorPalette labels", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Low' label when percent < 33 (value=0)", () => {
+    renderMeter(0);
+    expect(screen.getByText("Low")).toBeInTheDocument();
+  });
+
+  it("shows 'Medium' label when 33 ≤ percent < 66 (value=2, max=4 → 50%)", () => {
+    renderMeter(2, 4);
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+  });
+
+  it("shows 'High' label when percent >= 66 (value=4, max=4 → 100%)", () => {
+    renderMeter(4, 4);
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+
+  it("shows 'Low' for 1 out of 4 (25%)", () => {
+    renderMeter(1, 4);
+    expect(screen.getByText("Low")).toBeInTheDocument();
+  });
+
+  it("shows 'High' for 3 out of 4 (75%)", () => {
+    renderMeter(3, 4);
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/shared/utils/displayName.test.ts
+++ b/client-app/src/tests/shared/utils/displayName.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Branch coverage for shared/utils/displayName.ts:
+ * - !name (null / undefined / "") → "Unknown"
+ * - DELETED_PATTERN.test(name.trim()) → "Deleted User"
+ * - else → name as-is
+ */
+import { describe, it, expect } from "vitest";
+import { displayName } from "@/shared/utils/displayName";
+
+describe("displayName – null / undefined / empty → 'Unknown'", () => {
+  it("returns 'Unknown' for null", () => {
+    expect(displayName(null)).toBe("Unknown");
+  });
+
+  it("returns 'Unknown' for undefined", () => {
+    expect(displayName(undefined)).toBe("Unknown");
+  });
+
+  it("returns 'Unknown' for empty string", () => {
+    expect(displayName("")).toBe("Unknown");
+  });
+});
+
+describe("displayName – deleted_ pattern → 'Deleted User'", () => {
+  it("matches lowercase deleted_ prefix with 8 hex chars", () => {
+    expect(displayName("deleted_12345678")).toBe("Deleted User");
+  });
+
+  it("matches uppercase DELETED_ prefix (case-insensitive)", () => {
+    expect(displayName("DELETED_abcdef01")).toBe("Deleted User");
+  });
+
+  it("matches mixed hex characters after deleted_", () => {
+    expect(displayName("deleted_aAbBcCdD")).toBe("Deleted User");
+  });
+
+  it("trims whitespace before testing", () => {
+    expect(displayName("  deleted_12345678  ")).toBe("Deleted User");
+  });
+
+  it("does NOT match if hex part is not exactly 8 chars", () => {
+    expect(displayName("deleted_1234567")).toBe("deleted_1234567");
+    expect(displayName("deleted_123456789")).toBe("deleted_123456789");
+  });
+
+  it("does NOT match if not at start of string", () => {
+    expect(displayName("xdeleted_12345678")).toBe("xdeleted_12345678");
+  });
+});
+
+describe("displayName – regular names returned as-is", () => {
+  it("returns regular name unchanged", () => {
+    expect(displayName("Grimgork")).toBe("Grimgork");
+  });
+
+  it("returns name with spaces unchanged", () => {
+    expect(displayName("Player One")).toBe("Player One");
+  });
+
+  it("returns name that starts with 'deleted' but does not match full pattern", () => {
+    expect(displayName("deleted_user")).toBe("deleted_user");
+  });
+});


### PR DESCRIPTION
## Summary

- **UsernameUpdateForm** (9 tests): `user.username || ""` initial value (empty/non-empty), validation `!username || length < 3`, error clearing on re-type `if (error) setError("")`, `isGuest` branch (→ `updateGuestUsername` vs `updateAuthUsername`), `catch` Error/non-Error branches
- **UserStatsCard** (7 tests): loading skeleton state, faction count singular ("match") vs plural ("matches"), empty factions array hides section, zero activity → "No activity recorded yet" message, null stats defaults values to 0 via `??`
- **RegisterLogin** (4 tests): "Register/Login" button renders, click → opens drawer with title "Authentication", `auth-event open-drawer` → opens drawer, `auth-event close-drawer` → closes drawer
- **StatisticsPage** (15 tests): loading spinner, `err instanceof Error` → error message, non-Error → "Failed to load statistics", all four empty-section messages, `f.wins === 1` singular/"wins" plural, player factions subtext shown/hidden, `c.completed > 0` "done" badge, `recentTournaments.length > 0` section, `stats.cachedAt` "Updated" timestamp
- **MatchesSection** (16 tests): empty matches message, Round Robin badge + standings table, Swiss System badge, Double Elimination Winners/Losers/Grand Final sections, `gfMatches.length > 1` Bracket Reset badge, `isCurrentRound` "Current" badge, past round "Completed" badge, admin footer (Advance Round for SE, Finalize Tournament for RR), `onAdvanceRound` call

## Test plan
- [x] All 51 tests pass locally
- [x] MatchCard mocked to avoid deep prop requirements in MatchesSection tests

https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzgE7tpUec6UhMYWy5ryYm)_