### PR TITLE
SEO meta tags, robots.txt, and Caddy SPA cache header fix

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -41,7 +41,11 @@
         -Last-Modified
     }
 
-    @html path /
+    @html {
+        not path /assets/*
+        not path /api/*
+        not path /socket.io*
+    }
     header @html Cache-Control "no-cache, no-store, must-revalidate"
 
     @hashed_assets path_regexp /assets/.*\.[A-Za-z0-9_-]+\.(js|css|woff2?)$

--- a/client-app/index.html
+++ b/client-app/index.html
@@ -3,12 +3,30 @@
 
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Total War: Warhammer Tournament Organiser</title>
+  <meta name="description" content="Organise and compete in Total War: Warhammer tournaments. Create brackets, track match results, resolve disputes, and crown a champion." />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#1a0a0a" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Total War: Warhammer Tournament Organiser" />
+  <meta property="og:description" content="Organise and compete in Total War: Warhammer tournaments. Create brackets, track match results, and crown a champion." />
+  <meta property="og:image" content="/logo.svg" />
+  <meta property="og:locale" content="en_GB" />
+
+  <!-- Twitter / X -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Total War: Warhammer Tournament Organiser" />
+  <meta name="twitter:description" content="Organise and compete in Total War: Warhammer tournaments. Create brackets, track match results, and crown a champion." />
+  <meta name="twitter:image" content="/logo.svg" />
+
   <link rel="icon" type="image/svg+xml" href="/logo.svg">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Total Warhammer Tournament App</title>
+  <link rel="manifest" href="/site.webmanifest" />
   <link rel="stylesheet" href="/preload.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/client-app/public/robots.txt
+++ b/client-app/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Disallow: /api/

--- a/client-app/public/site.webmanifest
+++ b/client-app/public/site.webmanifest
@@ -1,5 +1,5 @@
 {
-    "name": "TW Tournament App",
+    "name": "Total War: Warhammer Tournament Organiser",
     "short_name": "TW Tournament",
     "icons": [
         {
@@ -13,7 +13,7 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
+    "theme_color": "#1a0a0a",
+    "background_color": "#1a0a0a",
     "display": "standalone"
 }


### PR DESCRIPTION
## Summary

- **SEO (`index.html`)**: Added `<meta name="description">`, Open Graph tags (`og:title`, `og:description`, `og:image`, `og:type`), Twitter Card tags, `<link rel="manifest">`, `<meta name="theme-color">`, and a more descriptive page title
- **`robots.txt`**: Created `client-app/public/robots.txt` allowing all crawlers, disallowing `/api/`
- **Caddyfile cache fix**: The `@html` matcher was `path /` — only the root path got `no-cache` headers; all other SPA routes (e.g. `/tournament/123`) had no Cache-Control set at all. Changed to a `not` matcher covering all non-asset, non-API, non-socket paths so every HTML response gets `no-cache, no-store, must-revalidate` as intended
- **`site.webmanifest`**: Updated app name and theme/background color to match the dark app theme (`#1a0a0a`)

## Test plan

- [ ] Visit `/`, `/tournament/<id>` etc. in DevTools Network tab — confirm `Cache-Control: no-cache, no-store, must-revalidate` on HTML responses
- [ ] Confirm `/assets/*.js` and `/assets/*.css` responses still have `Cache-Control: public, max-age=31536000, immutable`
- [ ] Check `<head>` in page source for OG/Twitter meta tags and manifest link
- [ ] Verify `robots.txt` is accessible at `/robots.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaSjXJ4WRz8atTwbt62M1o)_