### PR TITLE
fix: allow external images in markdown descriptions

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -35,9 +35,9 @@
         X-Frame-Options "SAMEORIGIN"
         Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
         Cross-Origin-Opener-Policy "same-origin"
-        Cross-Origin-Embedder-Policy "require-corp"
+        Cross-Origin-Embedder-Policy "credentialless"
         Cross-Origin-Resource-Policy "same-origin"
-        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; worker-src 'none'; frame-src 'none'; manifest-src 'self'; media-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; object-src 'none'"
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; worker-src 'none'; frame-src 'none'; manifest-src 'self'; media-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; object-src 'none'"
         -Last-Modified
     }
 

--- a/client-app/src/features/matches/components/TournamentDetail.tsx
+++ b/client-app/src/features/matches/components/TournamentDetail.tsx
@@ -349,6 +349,11 @@ const TournamentDetail: React.FC<Props> = ({
                       color: "var(--chakra-colors-verdigris-fg)",
                       textDecoration: "underline",
                     },
+                    "& img": {
+                      maxWidth: "100%",
+                      height: "auto",
+                      borderRadius: "4px",
+                    },
                   }}
                 >
                   <ReactMarkdown>{selected.description}</ReactMarkdown>

--- a/client-app/src/features/tournaments/components/TournamentViewPage.tsx
+++ b/client-app/src/features/tournaments/components/TournamentViewPage.tsx
@@ -451,6 +451,11 @@ const TournamentViewPage: React.FC<{ id?: string }> = ({ id: propId }) => {
                   borderColor: "var(--chakra-colors-border)",
                   margin: "0.75rem 0",
                 },
+                "& img": {
+                  maxWidth: "100%",
+                  height: "auto",
+                  borderRadius: "4px",
+                },
               }}
             >
               <ReactMarkdown>{tournament.description}</ReactMarkdown>


### PR DESCRIPTION
Fixes #170

Two Caddy security headers were blocking external images in markdown:

- CSP `img-src 'self' data:` expanded to `img-src 'self' data: https:`
- `Cross-Origin-Embedder-Policy` changed from `require-corp` to `credentialless`
- Added responsive img CSS to both markdown containers

Generated with [Claude Code](https://claude.ai/code)