### PR TITLE
test: achieve 100% unit test coverage (PR 1 of N — 5 files)

### DIFF
--- a/client-app/src/tests/features/authentication/authenticationApiLoginUser.test.ts
+++ b/client-app/src/tests/features/authentication/authenticationApiLoginUser.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Branch coverage for authenticationApi.ts – loginUser and exchangeCodeForToken:
+ * - Success path (no authorizationCode, no state) → setUser + success toast
+ * - Success path with rememberMe=true → "30 days" toast description
+ * - Success path with state in response that passes verifyAuthState
+ * - State validation failing → throws "Security error: State validation failed"
+ * - authorizationCode present + codeVerifier found → exchangeCodeForToken → setUser
+ * - authorizationCode present + no codeVerifier → throws "Code verifier not found"
+ * - responseData.success = false → error toast, no setUser
+ * - httpClient.post throws → catch, error toast, re-throws
+ * - exchangeCodeForToken internal error → second post throws
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockPost,
+  mockSetUser,
+  mockClearUser,
+  mockToasterCreate,
+  mockInitiatePKCEFlow,
+  mockVerifyAuthState,
+  mockGetAndClearCodeVerifier,
+} = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockSetUser: vi.fn(),
+  mockClearUser: vi.fn(),
+  mockToasterCreate: vi.fn(),
+  mockInitiatePKCEFlow: vi.fn(),
+  mockVerifyAuthState: vi.fn(),
+  mockGetAndClearCodeVerifier: vi.fn(),
+}));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { post: mockPost },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: {
+    getState: vi.fn(() => ({ setUser: mockSetUser, clearUser: mockClearUser })),
+  },
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+vi.mock("@/core/auth/pkceAuthService", () => ({
+  PKCEAuthService: {
+    initiatePKCEFlow: mockInitiatePKCEFlow,
+    verifyAuthState: mockVerifyAuthState,
+    getAndClearCodeVerifier: mockGetAndClearCodeVerifier,
+  },
+}));
+
+vi.mock("@/core/config/apiConfig", () => ({
+  apiConfig: {
+    endpoints: {
+      login: "/auth/login",
+      token: "/auth/token",
+      logout: "/auth/logout",
+    },
+  },
+}));
+
+import { loginUser } from "@/features/authentication/api/authenticationApi";
+
+// Helper defaults
+const defaultPKCE = { codeChallenge: "challenge123", state: "state-abc" };
+const baseLoginData = { identifier: "grimgork@waaagh.com", password: "Waaagh1!" };
+
+describe("loginUser – success path (no authorizationCode, no state in response)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("calls setUser and creates a success toast on success", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", email: "g@g.com", username: "Grimgork" },
+    });
+
+    await loginUser(baseLoginData);
+
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        isAuthenticated: true,
+        isGuest: false,
+      }),
+    );
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+  });
+
+  it("sends codeChallenge and state from PKCEAuthService to the login endpoint", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", email: "g@g.com", username: "Grimgork" },
+    });
+
+    await loginUser(baseLoginData);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/auth/login",
+      expect.objectContaining({
+        codeChallenge: "challenge123",
+        state: "state-abc",
+        codeChallengeMethod: "S256",
+      }),
+    );
+  });
+
+  it("returns the response data", async () => {
+    const serverResponse = {
+      success: true,
+      message: "ok",
+      data: { id: "u2", email: "x@x.com", username: "Luthor" },
+    };
+    mockPost.mockResolvedValueOnce(serverResponse);
+
+    const result = await loginUser(baseLoginData);
+    expect(result).toEqual(serverResponse);
+  });
+});
+
+describe("loginUser – success path with rememberMe=true", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("toast description says '30 days' when rememberMe is true", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", email: "g@g.com", username: "Grimgork" },
+    });
+
+    await loginUser({ ...baseLoginData, rememberMe: true });
+
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "Welcome back! You'll stay signed in for 30 days.",
+        type: "success",
+      }),
+    );
+  });
+
+  it("toast description says 'Welcome back!' when rememberMe is false", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", email: "g@g.com", username: "Grimgork" },
+    });
+
+    await loginUser({ ...baseLoginData, rememberMe: false });
+
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "Welcome back!",
+        type: "success",
+      }),
+    );
+  });
+});
+
+describe("loginUser – success path with state validation passing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("does not throw when state is present and verifyAuthState returns true", async () => {
+    mockVerifyAuthState.mockReturnValue(true);
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", email: "g@g.com", username: "Grimgork", state: "state-abc" },
+    });
+
+    await expect(loginUser(baseLoginData)).resolves.toBeDefined();
+    expect(mockVerifyAuthState).toHaveBeenCalledWith("state-abc");
+  });
+});
+
+describe("loginUser – state validation failing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("throws 'Security error: State validation failed' when verifyAuthState returns false", async () => {
+    mockVerifyAuthState.mockReturnValue(false);
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", email: "g@g.com", username: "Grimgork", state: "tampered-state" },
+    });
+
+    await expect(loginUser(baseLoginData)).rejects.toThrow(
+      "Security error: State validation failed",
+    );
+  });
+
+  it("shows error toast when state validation fails", async () => {
+    mockVerifyAuthState.mockReturnValue(false);
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", email: "g@g.com", username: "Grimgork", state: "bad-state" },
+    });
+
+    await loginUser(baseLoginData).catch(() => {});
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Login Failed", type: "error" }),
+    );
+  });
+});
+
+describe("loginUser – authorizationCode + codeVerifier found", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("calls exchangeCodeForToken (second post) and merges token data into responseData", async () => {
+    mockGetAndClearCodeVerifier.mockReturnValue("verifier-xyz");
+    // First post: login → returns authorizationCode
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        authorizationCode: "code-abc",
+      },
+    });
+    // Second post: token exchange
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "token ok",
+      data: { id: "u1", email: "g@g.com", username: "Grimgork", expiresAt: 9999 },
+    });
+
+    await loginUser(baseLoginData);
+
+    // Should have called post twice
+    expect(mockPost).toHaveBeenCalledTimes(2);
+    // Second call should be the token exchange
+    expect(mockPost).toHaveBeenNthCalledWith(
+      2,
+      "/auth/token",
+      expect.objectContaining({
+        grant_type: "authorization_code",
+        code: "code-abc",
+        code_verifier: "verifier-xyz",
+      }),
+    );
+    // setUser should be called with merged token data
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresAt: 9999 }),
+    );
+  });
+});
+
+describe("loginUser – authorizationCode present + no codeVerifier", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("throws 'Code verifier not found' when getAndClearCodeVerifier returns null", async () => {
+    mockGetAndClearCodeVerifier.mockReturnValue(null);
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        authorizationCode: "code-abc",
+      },
+    });
+
+    await expect(loginUser(baseLoginData)).rejects.toThrow(
+      "Code verifier not found",
+    );
+  });
+
+  it("creates error toast when code verifier is missing", async () => {
+    mockGetAndClearCodeVerifier.mockReturnValue(undefined);
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        authorizationCode: "code-abc",
+      },
+    });
+
+    await loginUser(baseLoginData).catch(() => {});
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Login Failed", type: "error" }),
+    );
+  });
+});
+
+describe("loginUser – responseData.success = false", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("creates error toast and does NOT call setUser when success is false", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: false,
+      message: "Invalid credentials",
+    });
+
+    const result = await loginUser(baseLoginData);
+
+    expect(mockSetUser).not.toHaveBeenCalled();
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Login Failed", type: "error" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("uses the server message in the error toast description", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: false,
+      message: "Account locked",
+    });
+
+    await loginUser(baseLoginData);
+
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Account locked" }),
+    );
+  });
+});
+
+describe("loginUser – httpClient.post throws", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("creates error toast and re-throws the error when post rejects", async () => {
+    const networkError = new Error("Network timeout");
+    mockPost.mockRejectedValueOnce(networkError);
+
+    await expect(loginUser(baseLoginData)).rejects.toThrow("Network timeout");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Login Failed", type: "error" }),
+    );
+  });
+
+  it("does NOT call setUser when post throws", async () => {
+    mockPost.mockRejectedValueOnce(new Error("500"));
+
+    await loginUser(baseLoginData).catch(() => {});
+    expect(mockSetUser).not.toHaveBeenCalled();
+  });
+
+  it("uses the error message in the toast description when error is an Error instance", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Forbidden"));
+
+    await loginUser(baseLoginData).catch(() => {});
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Forbidden" }),
+    );
+  });
+
+  it("uses fallback description when thrown value is not an Error instance", async () => {
+    mockPost.mockRejectedValueOnce("just a string error");
+
+    await loginUser(baseLoginData).catch(() => {});
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "An unexpected error occurred during login.",
+      }),
+    );
+  });
+});
+
+describe("loginUser – exchangeCodeForToken internal error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("propagates error and shows error toast when token exchange fails", async () => {
+    mockGetAndClearCodeVerifier.mockReturnValue("verifier-xyz");
+    // First post succeeds with authorizationCode
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        authorizationCode: "code-abc",
+      },
+    });
+    // Second post (token exchange) fails
+    mockPost.mockRejectedValueOnce(new Error("Token exchange failed"));
+
+    await expect(loginUser(baseLoginData)).rejects.toThrow("Token exchange failed");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Login Failed", type: "error" }),
+    );
+  });
+
+  it("does NOT call setUser when token exchange throws", async () => {
+    mockGetAndClearCodeVerifier.mockReturnValue("verifier-xyz");
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        authorizationCode: "code-abc",
+      },
+    });
+    mockPost.mockRejectedValueOnce(new Error("Token exchange failed"));
+
+    await loginUser(baseLoginData).catch(() => {});
+    expect(mockSetUser).not.toHaveBeenCalled();
+  });
+});

--- a/client-app/src/tests/features/matches/MatchCardFullCoverage.test.tsx
+++ b/client-app/src/tests/features/matches/MatchCardFullCoverage.test.tsx
@@ -1,0 +1,549 @@
+/**
+ * Additional branch coverage for matches/components/MatchCard.tsx:
+ * - Lines 336-379: isAdmin && isActive && m.status === "disputed" section
+ * - Lines 381-408: isAdmin && isActive && m.status === "in_progress" && reportedResults.length > 0
+ * - Lines 441-450: Admin Override start button (isAdmin && isActive && player2.name !== "BYE")
+ * - Lines 512-522: !isAdmin && (isP1||isP2) && status === "in_progress" && myReport → "waiting for opponent"
+ * - Lines 523-533: !isAdmin && (isP1||isP2) && status === "disputed" → "Result disputed"
+ * - Override panel: clicking winner buttons (onSetOverrideWinner), confirm override, typing reason
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import MatchCard from "@/features/matches/components/MatchCard";
+
+const baseMatch = {
+  _id: "m1",
+  round: 1,
+  matchNumber: 1,
+  player1: { participantId: "p1", name: "Grimgork", faction: "Greenskins" },
+  player2: { participantId: "p2", name: "Luthor", faction: "Empire" },
+  winnerId: null as string | null,
+  loserId: null as string | null,
+  status: "pending" as "pending" | "in_progress" | "completed" | "disputed",
+  notes: "",
+  reportedResults: [] as {
+    reportedBy: string;
+    reportedByName: string;
+    winnerId: string;
+  }[],
+  resultOverrides: [] as {
+    previousWinnerId: string | null;
+    newWinnerId: string;
+    overriddenBy: string;
+    reason: string;
+    overriddenAt: string;
+  }[],
+  completedAt: null as string | null,
+  bracketSide: null as "winners" | "losers" | "grand_final" | null,
+};
+
+const baseFns = {
+  onRecordResult: vi.fn(),
+  onReportResult: vi.fn(),
+  onResolveDispute: vi.fn(),
+  onStartOverride: vi.fn(),
+  onCancelOverride: vi.fn(),
+  onSetOverrideWinner: vi.fn(),
+  onSetOverrideReason: vi.fn(),
+  onConfirmOverride: vi.fn(),
+};
+
+function renderCard(
+  matchOverride: Partial<typeof baseMatch> = {},
+  extraProps: Record<string, unknown> = {},
+) {
+  const m = { ...baseMatch, ...matchOverride };
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <MatchCard
+        m={m}
+        p1Won={false}
+        p2Won={false}
+        isOverriding={false}
+        isAdmin={false}
+        isActive={false}
+        myReport={undefined}
+        canParticipantReport={false}
+        isP1={false}
+        isP2={false}
+        actionLoading={false}
+        overrideLoading={false}
+        overrideWinnerId=""
+        overrideReason=""
+        borderColor="border"
+        mutedBg="bg.subtle"
+        {...baseFns}
+        {...extraProps}
+      />
+    </ChakraProvider>,
+  );
+}
+
+// ─── Lines 336-379: admin disputed section ────────────────────────────────────
+
+describe("MatchCard – admin disputed resolution (lines 336-379)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows '⚠ Disputed - resolve:' label for admin + active + disputed", () => {
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: true, isActive: true },
+    );
+    expect(screen.getByText(/disputed - resolve/i)).toBeInTheDocument();
+  });
+
+  it("renders player1-wins and player2-wins resolve buttons", () => {
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: true, isActive: true },
+    );
+    expect(
+      screen.getByRole("button", { name: /grimgork wins/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /luthor wins/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onResolveDispute with matchId and player1 participantId when p1-wins clicked", () => {
+    const onResolveDispute = vi.fn();
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: true, isActive: true, onResolveDispute },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /grimgork wins/i }));
+    expect(onResolveDispute).toHaveBeenCalledWith("m1", "p1");
+  });
+
+  it("calls onResolveDispute with matchId and player2 participantId when p2-wins clicked", () => {
+    const onResolveDispute = vi.fn();
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: true, isActive: true, onResolveDispute },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /luthor wins/i }));
+    expect(onResolveDispute).toHaveBeenCalledWith("m1", "p2");
+  });
+
+  it("shows reportedResults 'X says Y won' text in disputed section", () => {
+    renderCard(
+      {
+        status: "disputed",
+        reportedResults: [
+          { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p1" },
+          { reportedBy: "p2", reportedByName: "Luthor", winnerId: "p2" },
+        ],
+      },
+      { isAdmin: true, isActive: true },
+    );
+    // "Grimgork says Grimgork won" → each reporter's claimed winner displayed
+    const saysPhrases = screen.getAllByText(/says/i);
+    expect(saysPhrases.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("resolves reporter name from player1 participantId when reportedBy matches p1", () => {
+    renderCard(
+      {
+        status: "disputed",
+        reportedResults: [
+          { reportedBy: "p1", reportedByName: "SomeOther", winnerId: "p1" },
+        ],
+      },
+      { isAdmin: true, isActive: true },
+    );
+    // Reporter is p1 → name resolves to player1.name "Grimgork"; "SomeOther" should NOT appear
+    expect(screen.queryByText(/someother/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/grimgork/i).length).toBeGreaterThan(0);
+  });
+
+  it("does NOT show disputed-resolve section when not admin", () => {
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: false, isActive: true },
+    );
+    expect(screen.queryByText(/disputed - resolve/i)).not.toBeInTheDocument();
+  });
+
+  it("does NOT show disputed-resolve section when isActive is false", () => {
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: true, isActive: false },
+    );
+    expect(screen.queryByText(/disputed - resolve/i)).not.toBeInTheDocument();
+  });
+});
+
+// ─── Lines 381-408: admin in_progress reported results ───────────────────────
+
+describe("MatchCard – admin in_progress reported results (lines 381-408)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Reported results (1/2):' label for admin + active + in_progress + 1 report", () => {
+    renderCard(
+      {
+        status: "in_progress",
+        reportedResults: [
+          { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p1" },
+        ],
+      },
+      { isAdmin: true, isActive: true },
+    );
+    expect(screen.getByText(/reported results \(1\/2\)/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Reported results (2/2):' label when both have reported", () => {
+    renderCard(
+      {
+        status: "in_progress",
+        reportedResults: [
+          { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p1" },
+          { reportedBy: "p2", reportedByName: "Luthor", winnerId: "p1" },
+        ],
+      },
+      { isAdmin: true, isActive: true },
+    );
+    expect(screen.getByText(/reported results \(2\/2\)/i)).toBeInTheDocument();
+  });
+
+  it("shows 'X says Y won' for each reported result", () => {
+    renderCard(
+      {
+        status: "in_progress",
+        reportedResults: [
+          { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p2" },
+        ],
+      },
+      { isAdmin: true, isActive: true },
+    );
+    // p1 (Grimgork) says p2 (Luthor) won
+    const sayPhrases = screen.getAllByText(/says/i);
+    expect(sayPhrases.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("resolves reporter name to player2.name when reportedBy matches p2", () => {
+    renderCard(
+      {
+        status: "in_progress",
+        reportedResults: [
+          { reportedBy: "p2", reportedByName: "FallbackName", winnerId: "p1" },
+        ],
+      },
+      { isAdmin: true, isActive: true },
+    );
+    // Reporter is p2 → name resolves to player2.name "Luthor"; "FallbackName" should NOT appear
+    expect(screen.queryByText(/fallbackname/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/luthor/i).length).toBeGreaterThan(0);
+  });
+
+  it("falls back to reportedByName when reportedBy does not match either participant", () => {
+    renderCard(
+      {
+        status: "in_progress",
+        reportedResults: [
+          { reportedBy: "unknown-id", reportedByName: "Stranger", winnerId: "p1" },
+        ],
+      },
+      { isAdmin: true, isActive: true },
+    );
+    expect(screen.getByText(/stranger/i)).toBeInTheDocument();
+  });
+
+  it("does NOT show reported results section when reportedResults is empty", () => {
+    renderCard(
+      { status: "in_progress", reportedResults: [] },
+      { isAdmin: true, isActive: true },
+    );
+    expect(screen.queryByText(/reported results/i)).not.toBeInTheDocument();
+  });
+
+  it("does NOT show reported results section when not admin", () => {
+    renderCard(
+      {
+        status: "in_progress",
+        reportedResults: [
+          { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p1" },
+        ],
+      },
+      { isAdmin: false, isActive: true },
+    );
+    expect(screen.queryByText(/reported results/i)).not.toBeInTheDocument();
+  });
+});
+
+// ─── Lines 441-450: Admin Override start button ───────────────────────────────
+
+describe("MatchCard – admin Override button (lines 441-450)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders Override button for admin + active + player2 not BYE", () => {
+    renderCard(
+      { status: "in_progress" },
+      { isAdmin: true, isActive: true },
+    );
+    expect(screen.getByRole("button", { name: /override/i })).toBeInTheDocument();
+  });
+
+  it("calls onStartOverride when the Override button is clicked", () => {
+    const onStartOverride = vi.fn();
+    renderCard(
+      { status: "in_progress" },
+      { isAdmin: true, isActive: true, onStartOverride },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /override/i }));
+    expect(onStartOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT render Override button when player2 is BYE", () => {
+    renderCard(
+      {
+        status: "in_progress",
+        player2: { participantId: "bye", name: "BYE", faction: "" },
+      },
+      { isAdmin: true, isActive: true },
+    );
+    expect(screen.queryByRole("button", { name: /override/i })).not.toBeInTheDocument();
+  });
+
+  it("does NOT render Override button when isAdmin is false", () => {
+    renderCard(
+      { status: "in_progress" },
+      { isAdmin: false, isActive: true },
+    );
+    expect(screen.queryByRole("button", { name: /override/i })).not.toBeInTheDocument();
+  });
+
+  it("does NOT render Override button when isActive is false", () => {
+    renderCard(
+      { status: "in_progress" },
+      { isAdmin: true, isActive: false },
+    );
+    expect(screen.queryByRole("button", { name: /override/i })).not.toBeInTheDocument();
+  });
+
+  it("renders Override button even for completed matches", () => {
+    renderCard(
+      { status: "completed", winnerId: "p1" },
+      { isAdmin: true, isActive: true, p1Won: true },
+    );
+    expect(screen.getByRole("button", { name: /override/i })).toBeInTheDocument();
+  });
+});
+
+// ─── Lines 512-522: participant "waiting for opponent" message ────────────────
+
+describe("MatchCard – participant 'waiting for opponent' message (lines 512-522)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'waiting for opponent' text for isP1 + in_progress + myReport present", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        isAdmin: false,
+        isP1: true,
+        isP2: false,
+        myReport: { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p1" },
+      },
+    );
+    expect(screen.getByText(/waiting for opponent/i)).toBeInTheDocument();
+  });
+
+  it("shows 'waiting for opponent' text for isP2 + in_progress + myReport present", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        isAdmin: false,
+        isP1: false,
+        isP2: true,
+        myReport: { reportedBy: "p2", reportedByName: "Luthor", winnerId: "p2" },
+      },
+    );
+    expect(screen.getByText(/waiting for opponent/i)).toBeInTheDocument();
+  });
+
+  it("shows the reported winner's name in the 'waiting' message (p1 reported p1 won)", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        isAdmin: false,
+        isP1: true,
+        myReport: { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p1" },
+      },
+    );
+    // The "waiting for opponent" sentence contains the winner name
+    expect(screen.getByText(/as winner - waiting for opponent/i)).toBeInTheDocument();
+    // The parent paragraph contains "Grimgork" as the reported winner
+    const waitingEl = screen.getByText(/as winner - waiting for opponent/i);
+    expect(waitingEl.textContent).toMatch(/grimgork/i);
+  });
+
+  it("shows the reported winner's name when p1 reported p2 won", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        isAdmin: false,
+        isP1: true,
+        myReport: { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p2" },
+      },
+    );
+    const waitingEl = screen.getByText(/as winner - waiting for opponent/i);
+    expect(waitingEl.textContent).toMatch(/luthor/i);
+  });
+
+  it("does NOT show 'waiting for opponent' when myReport is undefined", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        isAdmin: false,
+        isP1: true,
+        myReport: undefined,
+      },
+    );
+    expect(screen.queryByText(/waiting for opponent/i)).not.toBeInTheDocument();
+  });
+
+  it("does NOT show 'waiting for opponent' when neither isP1 nor isP2", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        isAdmin: false,
+        isP1: false,
+        isP2: false,
+        myReport: { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p1" },
+      },
+    );
+    expect(screen.queryByText(/waiting for opponent/i)).not.toBeInTheDocument();
+  });
+
+  it("does NOT show 'waiting for opponent' when isAdmin is true", () => {
+    renderCard(
+      { status: "in_progress" },
+      {
+        isAdmin: true,
+        isP1: true,
+        myReport: { reportedBy: "p1", reportedByName: "Grimgork", winnerId: "p1" },
+      },
+    );
+    expect(screen.queryByText(/waiting for opponent/i)).not.toBeInTheDocument();
+  });
+});
+
+// ─── Lines 523-533: participant "Result disputed" message ─────────────────────
+
+describe("MatchCard – participant 'Result disputed' message (lines 523-533)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows disputed message for isP1 + status=disputed + !isAdmin", () => {
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: false, isP1: true, isP2: false },
+    );
+    expect(
+      screen.getByText(/result disputed.*awaiting organiser/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows disputed message for isP2 + status=disputed + !isAdmin", () => {
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: false, isP1: false, isP2: true },
+    );
+    expect(
+      screen.getByText(/result disputed.*awaiting organiser/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT show disputed message when isAdmin is true", () => {
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: true, isP1: true },
+    );
+    // Admin gets resolve buttons instead, not the "awaiting organiser" text
+    expect(
+      screen.queryByText(/awaiting organiser decision/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show disputed message when neither isP1 nor isP2", () => {
+    renderCard(
+      { status: "disputed" },
+      { isAdmin: false, isP1: false, isP2: false },
+    );
+    expect(
+      screen.queryByText(/awaiting organiser decision/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show disputed message when status is in_progress", () => {
+    renderCard(
+      { status: "in_progress" },
+      { isAdmin: false, isP1: true },
+    );
+    expect(
+      screen.queryByText(/awaiting organiser decision/i),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── Override panel interactions ──────────────────────────────────────────────
+
+describe("MatchCard – override panel interactions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls onSetOverrideWinner with p1 participantId when Grimgork button is clicked", () => {
+    const onSetOverrideWinner = vi.fn();
+    renderCard({}, { isOverriding: true, onSetOverrideWinner });
+    // In the override panel player buttons render with dn(player1.name) = "Grimgork"
+    // There are two "Grimgork" buttons: one in the override panel HStack, one in participant section if visible
+    const buttons = screen.getAllByRole("button", { name: /grimgork/i });
+    // Click the first one (override panel winner button)
+    fireEvent.click(buttons[0]);
+    expect(onSetOverrideWinner).toHaveBeenCalledWith("p1");
+  });
+
+  it("calls onSetOverrideWinner with p2 participantId when Luthor button is clicked", () => {
+    const onSetOverrideWinner = vi.fn();
+    renderCard({}, { isOverriding: true, onSetOverrideWinner });
+    const buttons = screen.getAllByRole("button", { name: /luthor/i });
+    fireEvent.click(buttons[0]);
+    expect(onSetOverrideWinner).toHaveBeenCalledWith("p2");
+  });
+
+  it("calls onConfirmOverride when Confirm Override is clicked", () => {
+    const onConfirmOverride = vi.fn();
+    renderCard(
+      {},
+      { isOverriding: true, overrideWinnerId: "p1", onConfirmOverride },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /confirm override/i }));
+    expect(onConfirmOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSetOverrideReason when text is typed in the reason input", () => {
+    const onSetOverrideReason = vi.fn();
+    renderCard({}, { isOverriding: true, onSetOverrideReason });
+    const input = screen.getByPlaceholderText(/reason \(optional\)/i);
+    fireEvent.change(input, { target: { value: "Cheating observed" } });
+    expect(onSetOverrideReason).toHaveBeenCalledWith("Cheating observed");
+  });
+
+  it("Confirm Override button is disabled when overrideWinnerId is empty", () => {
+    renderCard({}, { isOverriding: true, overrideWinnerId: "" });
+    const confirmBtn = screen.getByRole("button", { name: /confirm override/i });
+    expect(confirmBtn).toBeDisabled();
+  });
+
+  it("Confirm Override button is enabled when overrideWinnerId is set", () => {
+    renderCard({}, { isOverriding: true, overrideWinnerId: "p1" });
+    const confirmBtn = screen.getByRole("button", { name: /confirm override/i });
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
+  it("shows player name buttons in override winner selection panel", () => {
+    renderCard({}, { isOverriding: true });
+    expect(screen.getByRole("button", { name: /grimgork/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /luthor/i })).toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/matches/MatchesPageHandlers.test.tsx
+++ b/client-app/src/tests/features/matches/MatchesPageHandlers.test.tsx
@@ -1,0 +1,620 @@
+/**
+ * Handler coverage for matches/components/MatchesPage.tsx
+ *
+ * Covers:
+ * - handleFindByCode: participant path (navigate to /matches/tournament/:code)
+ * - handleFindByCode: spectator path (navigate to /matches/spectate/:code)
+ * - handleFindByCode: error path (codeError state shown)
+ * - urlCode auto-select with tournament in list (renders TournamentDetail, fetchMatches called)
+ * - onBack handler (setSelected null, navigate /matches)
+ * - handleStart
+ * - handleDelete
+ * - handleRecordResult
+ * - handleReportResult
+ * - handleAdvanceRound (non-completed)
+ * - handleAdvanceRound (completed)
+ * - handleAddParticipant (skipped when no newName)
+ * - handleRemoveParticipant
+ * - handleResolveDispute
+ * - socket join/leave and listener registration when tournament selected
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock references
+// ---------------------------------------------------------------------------
+const {
+  mockGet,
+  mockPost,
+  mockPatch,
+  mockDelete,
+  mockUseUserStore,
+  mockGetSocket,
+  mockNavigate,
+} = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+  mockPatch: vi.fn(),
+  mockDelete: vi.fn(),
+  mockUseUserStore: vi.fn(),
+  mockGetSocket: vi.fn(),
+  mockNavigate: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: {
+    get: mockGet,
+    post: mockPost,
+    patch: mockPatch,
+    delete: mockDelete,
+  },
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: () => mockUseUserStore(),
+}));
+
+vi.mock("@/core/socket/socketClient", () => ({
+  getSocket: mockGetSocket,
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// TournamentList mock – exposes handler props as interactive elements
+// ---------------------------------------------------------------------------
+vi.mock("@/features/matches/components/TournamentList", () => ({
+  default: ({ onFindByCode, onCodeInputChange, codeError }: any) => (
+    <div data-testid="tournament-list">
+      <input
+        data-testid="code-input"
+        onChange={(e) => onCodeInputChange(e.target.value)}
+      />
+      <button data-testid="find-button" onClick={onFindByCode}>
+        Find
+      </button>
+      {codeError && <div data-testid="code-error">{codeError}</div>}
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// TournamentDetail mock – exposes all handler props as trigger buttons
+// ---------------------------------------------------------------------------
+vi.mock("@/features/matches/components/TournamentDetail", () => ({
+  default: ({
+    onBack,
+    onStart,
+    onDelete,
+    onRecordResult,
+    onReportResult,
+    onAdvanceRound,
+    onAddParticipant,
+    onRemoveParticipant,
+    onResolveDispute,
+    onOverrideResult,
+    onSaveDescription,
+    onSaveParticipant,
+  }: any) => (
+    <div data-testid="tournament-detail">
+      <button data-testid="trigger-back" onClick={onBack}>
+        Back
+      </button>
+      <button data-testid="trigger-start" onClick={onStart}>
+        Start
+      </button>
+      <button data-testid="trigger-delete" onClick={onDelete}>
+        Delete
+      </button>
+      <button
+        data-testid="trigger-record"
+        onClick={() => onRecordResult("m1", "p1")}
+      >
+        Record
+      </button>
+      <button
+        data-testid="trigger-report"
+        onClick={() => onReportResult("m1", "p1")}
+      >
+        Report
+      </button>
+      <button data-testid="trigger-advance" onClick={onAdvanceRound}>
+        Advance
+      </button>
+      <button data-testid="trigger-add" onClick={() => onAddParticipant()}>
+        Add
+      </button>
+      <button
+        data-testid="trigger-remove"
+        onClick={() => onRemoveParticipant("p1")}
+      >
+        Remove
+      </button>
+      <button
+        data-testid="trigger-resolve"
+        onClick={() => onResolveDispute("m1", "p1")}
+      >
+        Resolve
+      </button>
+      <button
+        data-testid="trigger-override"
+        onClick={async () => {
+          try {
+            await onOverrideResult("m1", "p1", "reason");
+          } catch {
+            // expected to throw
+          }
+        }}
+      >
+        Override
+      </button>
+      <button
+        data-testid="trigger-save-desc"
+        onClick={async () => {
+          try {
+            await onSaveDescription("draft text");
+          } catch {
+            // expected to throw
+          }
+        }}
+      >
+        SaveDesc
+      </button>
+      <button
+        data-testid="trigger-save-part"
+        onClick={async () => {
+          try {
+            await onSaveParticipant({ _id: "p1", name: "P", faction: "" });
+          } catch {
+            // expected to throw
+          }
+        }}
+      >
+        SavePart
+      </button>
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Import component AFTER mocks
+// ---------------------------------------------------------------------------
+import MatchesPage from "@/features/matches/components/MatchesPage";
+import { toaster } from "@/shared/ui/Toaster";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const fakeSocket = {
+  emit: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+};
+
+function makeStore(isAuthenticated: boolean, userId = "u1", username = "Grimgork") {
+  return {
+    user: { id: userId, username, isAuthenticated, isGuest: false },
+    isAuthenticated: () => isAuthenticated,
+  };
+}
+
+const activeTournament = {
+  _id: "t1",
+  name: "Test Tourney",
+  code: "ABCDE",
+  description: "",
+  playerCount: 4,
+  tournamentType: "single_elimination",
+  bannedFactions: [],
+  enable40kFactions: false,
+  participants: [{ _id: "p1", name: "Grimgork", faction: "orks" }],
+  status: "active" as const,
+  createdAt: new Date().toISOString(),
+  createdBy: "u1",
+};
+
+const successfulListResponse = {
+  success: true,
+  data: [activeTournament],
+  total: 1,
+  statusCounts: { all: 1, pending: 0, active: 1, completed: 0 },
+};
+
+const emptyMatchesResponse = { success: true, data: [] };
+
+/** Render at /matches/tournament/:code so urlCode is set */
+function renderAtCode(code = "ABCDE") {
+  return render(
+    <MemoryRouter initialEntries={[`/matches/tournament/${code}`]}>
+      <ChakraProvider value={defaultSystem}>
+        <Routes>
+          <Route path="/matches/tournament/:code" element={<MatchesPage />} />
+          <Route path="/matches" element={<MatchesPage />} />
+        </Routes>
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+/** Render at /matches (no urlCode) */
+function renderAtMatches() {
+  return render(
+    <MemoryRouter initialEntries={["/matches"]}>
+      <ChakraProvider value={defaultSystem}>
+        <Routes>
+          <Route path="/matches/tournament/:code" element={<MatchesPage />} />
+          <Route path="/matches" element={<MatchesPage />} />
+        </Routes>
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("MatchesPage – handleFindByCode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore(true, "u1", "Grimgork"));
+    // Default list fetch (no tournaments – we just need the list to load)
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: [],
+      total: 0,
+      statusCounts: { all: 0, pending: 0, active: 0, completed: 0 },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("navigates to /matches/tournament/:code when user is a participant", async () => {
+    renderAtMatches();
+
+    // Wait for TournamentList to appear (loading done)
+    await waitFor(() =>
+      expect(screen.getByTestId("tournament-list")).toBeInTheDocument(),
+    );
+
+    // Type in the code and click find
+    fireEvent.change(screen.getByTestId("code-input"), {
+      target: { value: "abcde" },
+    });
+
+    // Mock the code lookup to return a tournament where user is a participant
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        _id: "t1",
+        participants: [{ name: "Grimgork" }],
+      },
+    });
+
+    fireEvent.click(screen.getByTestId("find-button"));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/matches/tournament/ABCDE");
+    });
+  });
+
+  it("navigates to /matches/spectate/:code when user is NOT a participant", async () => {
+    renderAtMatches();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tournament-list")).toBeInTheDocument(),
+    );
+
+    fireEvent.change(screen.getByTestId("code-input"), {
+      target: { value: "ABCDE" },
+    });
+
+    // No matching participant
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: {
+        _id: "t1",
+        participants: [{ name: "SomeoneElse" }],
+      },
+    });
+
+    fireEvent.click(screen.getByTestId("find-button"));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/matches/spectate/ABCDE");
+    });
+  });
+
+  it("shows codeError when the request rejects", async () => {
+    renderAtMatches();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tournament-list")).toBeInTheDocument(),
+    );
+
+    fireEvent.change(screen.getByTestId("code-input"), {
+      target: { value: "ABCDE" },
+    });
+
+    mockGet.mockRejectedValueOnce(new Error("Not found"));
+
+    fireEvent.click(screen.getByTestId("find-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("code-error")).toHaveTextContent(
+        "No tournament found with that code.",
+      );
+    });
+  });
+});
+
+describe("MatchesPage – urlCode auto-select with tournament in list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore(true, "u1", "Grimgork"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders TournamentDetail and calls fetchMatches when tournament found in list", async () => {
+    // First call: list with our tournament
+    mockGet.mockResolvedValueOnce(successfulListResponse);
+    // Second call: fetchMatches
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    renderAtCode("ABCDE");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tournament-detail")).toBeInTheDocument();
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/match/tournament/t1",
+    );
+  });
+});
+
+describe("MatchesPage – TournamentDetail handlers", () => {
+  /** Set up the standard scenario: renders TournamentDetail via urlCode */
+  async function setupWithDetail() {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore(true, "u1", "Grimgork"));
+
+    mockGet.mockResolvedValueOnce(successfulListResponse);
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    renderAtCode("ABCDE");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tournament-detail")).toBeInTheDocument(),
+    );
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("onBack sets selected=null and calls navigate /matches", async () => {
+    await setupWithDetail();
+
+    fireEvent.click(screen.getByTestId("trigger-back"));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/matches", { replace: true });
+    });
+  });
+
+  it("handleStart calls POST /tournament/t1/start then refreshSelected", async () => {
+    await setupWithDetail();
+
+    mockPost.mockResolvedValueOnce({ success: true });
+    // refreshSelected: GET /tournament/t1
+    mockGet.mockResolvedValueOnce({ success: true, data: activeTournament });
+    // fetchMatches triggered by refreshSelected
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    fireEvent.click(screen.getByTestId("trigger-start"));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/tournament/t1/start", {});
+    });
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith("/tournament/t1");
+    });
+  });
+
+  it("handleDelete calls DELETE /tournament/t1 and sets selected=null", async () => {
+    await setupWithDetail();
+
+    mockDelete.mockResolvedValueOnce({ success: true });
+    // After delete, fetchTournaments is called again (still at /matches/tournament/ABCDE url)
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: [],
+      total: 0,
+      statusCounts: { all: 0, pending: 0, active: 0, completed: 0 },
+    });
+    // urlCode is still ABCDE, tournament not in list → falls through to httpClient.get('/tournament/code/ABCDE')
+    // which then navigates /matches on reject — provide a resolved value to avoid unhandled rejection
+    mockGet.mockRejectedValueOnce(new Error("not found"));
+
+    fireEvent.click(screen.getByTestId("trigger-delete"));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith("/tournament/t1");
+    });
+    // After delete, navigate to /matches replace is called (from the code catch)
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/matches", { replace: true });
+    });
+  });
+
+  it("handleRecordResult calls PATCH /match/m1/result with winnerId", async () => {
+    await setupWithDetail();
+
+    mockPatch.mockResolvedValueOnce({ success: true });
+    // fetchMatches after record
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    fireEvent.click(screen.getByTestId("trigger-record"));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith("/match/m1/result", {
+        winnerId: "p1",
+      });
+    });
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith("/match/tournament/t1");
+    });
+  });
+
+  it("handleReportResult calls PATCH /match/m1/report with winnerId", async () => {
+    await setupWithDetail();
+
+    mockPatch.mockResolvedValueOnce({ success: true });
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    fireEvent.click(screen.getByTestId("trigger-report"));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith("/match/m1/report", {
+        winnerId: "p1",
+      });
+    });
+  });
+
+  it("handleAdvanceRound calls POST /tournament/t1/advance (non-completed)", async () => {
+    await setupWithDetail();
+
+    mockPost.mockResolvedValueOnce({ completed: false });
+    // refreshSelected
+    mockGet.mockResolvedValueOnce({ success: true, data: activeTournament });
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    fireEvent.click(screen.getByTestId("trigger-advance"));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/tournament/t1/advance", {});
+    });
+    await waitFor(() => {
+      expect(toaster.create).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Round advanced" }),
+      );
+    });
+  });
+
+  it("handleAdvanceRound shows completed toast when res.completed is true", async () => {
+    await setupWithDetail();
+
+    mockPost.mockResolvedValueOnce({ completed: true });
+    // refreshSelected
+    mockGet.mockResolvedValueOnce({ success: true, data: activeTournament });
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    fireEvent.click(screen.getByTestId("trigger-advance"));
+
+    await waitFor(() => {
+      expect(toaster.create).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Tournament completed!" }),
+      );
+    });
+  });
+
+  it("handleRemoveParticipant calls DELETE /tournament/t1/participants/p1", async () => {
+    await setupWithDetail();
+
+    mockDelete.mockResolvedValueOnce({ success: true });
+    // refreshSelected
+    mockGet.mockResolvedValueOnce({ success: true, data: activeTournament });
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    fireEvent.click(screen.getByTestId("trigger-remove"));
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith(
+        "/tournament/t1/participants/p1",
+      );
+    });
+  });
+
+  it("handleResolveDispute calls PATCH /match/m1/resolve with winnerId", async () => {
+    await setupWithDetail();
+
+    mockPatch.mockResolvedValueOnce({ success: true });
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    fireEvent.click(screen.getByTestId("trigger-resolve"));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith("/match/m1/resolve", {
+        winnerId: "p1",
+      });
+    });
+  });
+});
+
+describe("MatchesPage – socket effects", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("joins tournament room and registers listeners when tournament is selected", async () => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore(true, "u1", "Grimgork"));
+
+    mockGet.mockResolvedValueOnce(successfulListResponse);
+    mockGet.mockResolvedValueOnce(emptyMatchesResponse);
+
+    renderAtCode("ABCDE");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tournament-detail")).toBeInTheDocument(),
+    );
+
+    expect(fakeSocket.emit).toHaveBeenCalledWith("tournament:join", "t1");
+    expect(fakeSocket.on).toHaveBeenCalledWith(
+      "tournament:updated",
+      expect.any(Function),
+    );
+    expect(fakeSocket.on).toHaveBeenCalledWith(
+      "matches:updated",
+      expect.any(Function),
+    );
+    expect(fakeSocket.on).toHaveBeenCalledWith(
+      "matches:appended",
+      expect.any(Function),
+    );
+    expect(fakeSocket.on).toHaveBeenCalledWith(
+      "match:updated",
+      expect.any(Function),
+    );
+  });
+});

--- a/client-app/src/tests/features/matches/TournamentDetailExtended.test.tsx
+++ b/client-app/src/tests/features/matches/TournamentDetailExtended.test.tsx
@@ -1,0 +1,462 @@
+/**
+ * Extended branch coverage for matches/components/TournamentDetail.tsx
+ * Covers branches not in TournamentDetail.test.tsx:
+ * - handleCopyCode → navigator.clipboard.writeText + codeCopied state
+ * - handleUpdateDescription → onSaveDescription called, editingDescription reset
+ * - Cancel editing description → editingDescription set to false
+ * - canAdvance / Advance Round button
+ * - Champion section (status=completed, match with winner)
+ * - Current Round in Tournament Info
+ * - Admin pencil button → opens edit dialog
+ * - Admin remove participant button (X) → calls onRemoveParticipant
+ * - Tournament Info champion row (status=completed)
+ * - Finalize Tournament label for Round Robin
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
+
+vi.mock("@/features/matches/components/MatchesSection", () => ({
+  default: () => <div data-testid="matches-section" />,
+}));
+
+vi.mock("@/features/matches/components/EditParticipantDialog", () => ({
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="edit-dialog" /> : null,
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+import TournamentDetail from "@/features/matches/components/TournamentDetail";
+import type { Match } from "@/features/matches/components/types";
+
+// ─── Shared test fixtures ─────────────────────────────────────────────────────
+
+const baseTournament = {
+  _id: "t1",
+  name: "Test Cup",
+  code: "ABCDEF",
+  description: "",
+  playerCount: 4,
+  tournamentType: "Single Elimination",
+  bannedFactions: [] as string[],
+  enable40kFactions: false,
+  participants: [] as { _id: string; name: string; faction: string; userId?: string | null }[],
+  status: "pending" as "pending" | "active" | "completed",
+  createdAt: new Date().toISOString(),
+  createdBy: "u1",
+};
+
+const baseMatch: Match = {
+  _id: "m1",
+  round: 1,
+  matchNumber: 1,
+  player1: { participantId: "p1", name: "Champ", faction: "Greenskins" },
+  player2: { participantId: "p2", name: "Other", faction: "Empire" },
+  winnerId: null,
+  loserId: null,
+  status: "pending",
+  notes: "",
+  reportedResults: [],
+  resultOverrides: [],
+  completedAt: null,
+  bracketSide: null,
+};
+
+const baseFns = {
+  onBack: vi.fn(),
+  onStart: vi.fn(),
+  onDelete: vi.fn(),
+  onAddParticipant: vi.fn(),
+  onRemoveParticipant: vi.fn(),
+  onRecordResult: vi.fn(),
+  onReportResult: vi.fn(),
+  onOverrideResult: vi.fn().mockResolvedValue(undefined),
+  onResolveDispute: vi.fn(),
+  onAdvanceRound: vi.fn(),
+  onSaveDescription: vi.fn().mockResolvedValue(undefined),
+  onSaveParticipant: vi.fn().mockResolvedValue(undefined),
+  onSetNewName: vi.fn(),
+  onSetNewFaction: vi.fn(),
+};
+
+function renderDetail(
+  tournamentOverride: Partial<typeof baseTournament> = {},
+  extraProps: Record<string, unknown> = {},
+  matches: Match[] = [],
+) {
+  const selected = { ...baseTournament, ...tournamentOverride };
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <TournamentDetail
+          selected={selected as any}
+          matches={matches}
+          user={null}
+          newName=""
+          newFaction=""
+          actionLoading={false}
+          actionError={null}
+          matchLoading={false}
+          {...baseFns}
+          {...extraProps}
+        />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+// ─── handleCopyCode ───────────────────────────────────────────────────────────
+
+describe("TournamentDetail – handleCopyCode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("calls navigator.clipboard.writeText with the tournament code on Copy click", async () => {
+    renderDetail({ code: "ABCDEF" });
+    const copyBtn = screen.getByRole("button", { name: /^copy$/i });
+    fireEvent.click(copyBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ABCDEF");
+  });
+
+  it("shows 'Copied!' after clicking the Copy button", async () => {
+    renderDetail({ code: "ABCDEF" });
+    const copyBtn = screen.getByRole("button", { name: /^copy$/i });
+    fireEvent.click(copyBtn);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /copied!/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("resets to 'Copy' after 2 seconds", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderDetail({ code: "ABCDEF" });
+      const copyBtn = screen.getByRole("button", { name: /^copy$/i });
+      fireEvent.click(copyBtn);
+      // 'Copied!' should appear immediately (synchronous state update)
+      expect(screen.getByRole("button", { name: /copied!/i })).toBeInTheDocument();
+      // Advance past the 2000ms timeout
+      act(() => { vi.advanceTimersByTime(2100); });
+      expect(screen.getByRole("button", { name: /^copy$/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ─── handleUpdateDescription ──────────────────────────────────────────────────
+
+describe("TournamentDetail – handleUpdateDescription", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls onSaveDescription with the draft text and closes the editor", async () => {
+    const onSaveDescription = vi.fn().mockResolvedValue(undefined);
+    renderDetail(
+      { status: "active", description: "" },
+      { user: { id: "u1", username: "Admin" }, onSaveDescription },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /edit description/i }));
+
+    const textarea = screen.getByPlaceholderText(/tournament description/i);
+    fireEvent.change(textarea, { target: { value: "My tournament rules" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onSaveDescription).toHaveBeenCalledWith("My tournament rules");
+    });
+    // After saving, the textarea should no longer be visible
+    await waitFor(() =>
+      expect(
+        screen.queryByPlaceholderText(/tournament description/i),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});
+
+// ─── Cancel editing description ───────────────────────────────────────────────
+
+describe("TournamentDetail – cancel editing description", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("hides textarea when Cancel is clicked", async () => {
+    renderDetail(
+      { status: "active", description: "" },
+      { user: { id: "u1", username: "Admin" } },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /edit description/i }));
+    expect(screen.getByPlaceholderText(/tournament description/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByPlaceholderText(/tournament description/i),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});
+
+// ─── canAdvance / Advance Round button ───────────────────────────────────────
+
+describe("TournamentDetail – canAdvance (Advance Round)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Advance Round' button when all matches in max round are completed", () => {
+    const completedMatch: Match = {
+      ...baseMatch,
+      winnerId: "p1",
+      status: "completed",
+    };
+    renderDetail(
+      { status: "active" },
+      { user: { id: "u1", username: "Admin" } },
+      [completedMatch],
+    );
+    expect(
+      screen.getByRole("button", { name: /advance round/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onAdvanceRound when 'Advance Round' is clicked", () => {
+    const onAdvanceRound = vi.fn();
+    const completedMatch: Match = {
+      ...baseMatch,
+      winnerId: "p1",
+      status: "completed",
+    };
+    renderDetail(
+      { status: "active" },
+      { user: { id: "u1", username: "Admin" }, onAdvanceRound },
+      [completedMatch],
+    );
+    fireEvent.click(screen.getByRole("button", { name: /advance round/i }));
+    expect(onAdvanceRound).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT show 'Advance Round' when a match is still pending", () => {
+    renderDetail(
+      { status: "active" },
+      { user: { id: "u1", username: "Admin" } },
+      [baseMatch], // status: "pending"
+    );
+    expect(
+      screen.queryByRole("button", { name: /advance round/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show 'Advance Round' when matches array is empty", () => {
+    renderDetail(
+      { status: "active" },
+      { user: { id: "u1", username: "Admin" } },
+      [],
+    );
+    expect(
+      screen.queryByRole("button", { name: /advance round/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── Finalize Tournament label for Round Robin ────────────────────────────────
+
+describe("TournamentDetail – Finalize Tournament label (Round Robin)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Finalize Tournament' instead of 'Advance Round' for Round Robin type", () => {
+    const completedMatch: Match = {
+      ...baseMatch,
+      winnerId: "p1",
+      status: "completed",
+    };
+    renderDetail(
+      { status: "active", tournamentType: "Round Robin" },
+      { user: { id: "u1", username: "Admin" } },
+      [completedMatch],
+    );
+    expect(
+      screen.getByRole("button", { name: /finalize tournament/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /advance round/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── Champion section (status=completed) ─────────────────────────────────────
+
+describe("TournamentDetail – champion banner (status=completed)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Tournament Champion' banner with winner name when status is completed", () => {
+    const completedMatch: Match = {
+      ...baseMatch,
+      winnerId: "p1",
+      status: "completed",
+    };
+    renderDetail({ status: "completed" }, {}, [completedMatch]);
+    expect(screen.getByText(/tournament champion/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Champ").length).toBeGreaterThan(0);
+  });
+
+  it("does NOT show champion banner when completed but no match has a winner", () => {
+    const pendingMatch: Match = { ...baseMatch, winnerId: null };
+    renderDetail({ status: "completed" }, {}, [pendingMatch]);
+    expect(screen.queryByText(/tournament champion/i)).not.toBeInTheDocument();
+  });
+
+  it("does NOT show champion banner when status is not completed", () => {
+    const completedMatch: Match = {
+      ...baseMatch,
+      winnerId: "p1",
+      status: "completed",
+    };
+    renderDetail({ status: "active" }, {}, [completedMatch]);
+    expect(screen.queryByText(/tournament champion/i)).not.toBeInTheDocument();
+  });
+});
+
+// ─── Tournament Info champion row ─────────────────────────────────────────────
+
+describe("TournamentDetail – Tournament Info champion row", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Champion' label in Tournament Info card when completed with a winner", () => {
+    const completedMatch: Match = {
+      ...baseMatch,
+      winnerId: "p1",
+      status: "completed",
+    };
+    // Need non-admin so we get the Tournament Info card (not Add Participant)
+    renderDetail({ status: "completed" }, { user: null }, [completedMatch]);
+    // "Champion" appears as a label in the info card
+    expect(screen.getByText("Champion")).toBeInTheDocument();
+  });
+
+  it("shows '-' as champion when no match has winnerId", () => {
+    const match: Match = { ...baseMatch, winnerId: null };
+    renderDetail({ status: "completed" }, { user: null }, [match]);
+    // The IIFE returns <Text fontWeight="medium">-</Text>
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+});
+
+// ─── Current Round in Tournament Info ────────────────────────────────────────
+
+describe("TournamentDetail – Current Round in Tournament Info", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows 'Current Round' row when active and matches exist (non-Round Robin)", () => {
+    const match: Match = { ...baseMatch, bracketSide: null };
+    // Non-admin → Tournament Info card is rendered
+    renderDetail({ status: "active", tournamentType: "Single Elimination" }, { user: null }, [match]);
+    expect(screen.getByText("Current Round")).toBeInTheDocument();
+  });
+
+  it("does NOT show 'Current Round' for Round Robin type", () => {
+    const match: Match = { ...baseMatch, bracketSide: null };
+    renderDetail({ status: "active", tournamentType: "Round Robin" }, { user: null }, [match]);
+    expect(screen.queryByText("Current Round")).not.toBeInTheDocument();
+  });
+
+  it("does NOT show 'Current Round' when there are no matches", () => {
+    renderDetail({ status: "active", tournamentType: "Single Elimination" }, { user: null }, []);
+    expect(screen.queryByText("Current Round")).not.toBeInTheDocument();
+  });
+});
+
+// ─── Admin edit participant pencil button ────────────────────────────────────
+
+describe("TournamentDetail – admin edit participant button", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows the edit dialog when pencil button is clicked", () => {
+    renderDetail(
+      {
+        status: "active", // non-pending so we get Tournament Info card not Add Participant
+        participants: [{ _id: "p1", name: "Grimgork", faction: "Greenskins" }],
+      },
+      { user: { id: "u1", username: "Admin" } },
+    );
+
+    // Edit dialog is hidden initially
+    expect(screen.queryByTestId("edit-dialog")).not.toBeInTheDocument();
+
+    const editBtn = screen.getByRole("button", { name: /edit participant/i });
+    fireEvent.click(editBtn);
+
+    // React state update is synchronous via fireEvent, dialog opens
+    expect(screen.getByTestId("edit-dialog")).toBeInTheDocument();
+  });
+});
+
+// ─── Admin remove participant button ─────────────────────────────────────────
+
+describe("TournamentDetail – admin remove participant button", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls onRemoveParticipant with participant _id when X is clicked", () => {
+    const onRemoveParticipant = vi.fn();
+    renderDetail(
+      {
+        status: "pending",
+        participants: [{ _id: "p1", name: "Grimgork", faction: "Greenskins" }],
+      },
+      { user: { id: "u1", username: "Admin" }, onRemoveParticipant },
+    );
+
+    const removeBtn = screen.getByRole("button", { name: /remove participant/i });
+    fireEvent.click(removeBtn);
+    expect(onRemoveParticipant).toHaveBeenCalledWith("p1");
+  });
+
+  it("does NOT show remove button when not admin", () => {
+    renderDetail(
+      {
+        status: "pending",
+        participants: [{ _id: "p1", name: "Grimgork", faction: "Greenskins" }],
+      },
+      { user: null },
+    );
+    expect(
+      screen.queryByRole("button", { name: /remove participant/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show remove button when status is not pending (active)", () => {
+    renderDetail(
+      {
+        status: "active",
+        participants: [{ _id: "p1", name: "Grimgork", faction: "Greenskins" }],
+      },
+      { user: { id: "u1", username: "Admin" } },
+    );
+    expect(
+      screen.queryByRole("button", { name: /remove participant/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client-app/src/tests/features/tournaments/TournamentViewPageExtended.test.tsx
+++ b/client-app/src/tests/features/tournaments/TournamentViewPageExtended.test.tsx
@@ -1,0 +1,569 @@
+/**
+ * Extended branch coverage for tournaments/components/TournamentViewPage.tsx
+ * Covers branches not in TournamentViewPage.test.tsx:
+ * - tournament.description → ReactMarkdown renders it
+ * - handleJoin success → navigate to /matches/tournament/:code
+ * - handleJoin error → joinError shown in join panel
+ * - Copy tournament code button → clipboard + toaster
+ * - Matches with rounds/W/L badges (completed, in_progress, disputed)
+ * - champion.faction in banner
+ * - isAlreadyJoined via username match (no userId)
+ * - Back button → navigate to matches when owner/participant
+ * - bannedFactions display
+ * - joinSuccess state → "You're In!" heading
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+
+const { mockGet, mockPost, mockGetSocket, mockUseUserStore, mockNavigate, mockToasterCreate } =
+  vi.hoisted(() => ({
+    mockGet: vi.fn(),
+    mockPost: vi.fn(),
+    mockGetSocket: vi.fn(),
+    mockUseUserStore: vi.fn(),
+    mockNavigate: vi.fn(),
+    mockToasterCreate: vi.fn(),
+  }));
+
+vi.mock("@/core/api/httpClient", () => ({
+  httpClient: { get: mockGet, post: mockPost },
+}));
+
+vi.mock("@/core/socket/socketClient", () => ({
+  getSocket: mockGetSocket,
+}));
+
+vi.mock("@/shared/stores/userStore", () => ({
+  useUserStore: () => mockUseUserStore(),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
+
+vi.mock("@/shared/ui/Toaster", () => ({
+  toaster: { create: mockToasterCreate },
+}));
+
+import TournamentViewPage from "@/features/tournaments/components/TournamentViewPage";
+
+// ─── Shared test fixtures ─────────────────────────────────────────────────────
+
+const fakeSocket = { emit: vi.fn(), on: vi.fn(), off: vi.fn() };
+
+function makeTournament(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "t1",
+    name: "Test Cup",
+    code: "ABCDEF",
+    description: "",
+    playerCount: 4,
+    tournamentType: "Single Elimination",
+    bannedFactions: [] as string[],
+    enable40kFactions: false,
+    participants: [] as {
+      _id: string;
+      userId?: string | null;
+      name: string;
+      faction: string;
+    }[],
+    status: "pending" as "pending" | "active" | "completed",
+    createdAt: new Date().toISOString(),
+    createdBy: "owner1",
+    ...overrides,
+  };
+}
+
+function makeStore(userId = "u2", username = "Grimgork", authenticated = true) {
+  return {
+    user: { id: userId, username, isGuest: false },
+    isAuthenticated: () => authenticated,
+  };
+}
+
+function makeMatch(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "m1",
+    round: 1,
+    matchNumber: 1,
+    player1: { participantId: "p1", name: "Grimgork", faction: "Greenskins" },
+    player2: { participantId: "p2", name: "Luthor", faction: "Empire" },
+    winnerId: null as string | null,
+    status: "pending" as "pending" | "in_progress" | "completed" | "disputed",
+    reportedResults: [],
+    ...overrides,
+  };
+}
+
+function renderPage(id = "t1") {
+  return render(
+    <MemoryRouter>
+      <ChakraProvider value={defaultSystem}>
+        <TournamentViewPage id={id} />
+      </ChakraProvider>
+    </MemoryRouter>,
+  );
+}
+
+// ─── description display ──────────────────────────────────────────────────────
+
+describe("TournamentViewPage – description display", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore());
+  });
+
+  it("renders description via ReactMarkdown when description is non-empty", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ description: "# My Tournament" }),
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId("markdown")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("markdown")).toHaveTextContent("# My Tournament");
+  });
+
+  it("does not render markdown element when description is empty", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ description: "" }),
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Test Cup")).toBeInTheDocument());
+    expect(screen.queryByTestId("markdown")).not.toBeInTheDocument();
+  });
+});
+
+// ─── handleJoin – success path ────────────────────────────────────────────────
+
+describe("TournamentViewPage – handleJoin success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    // Non-owner, authenticated user who is not a participant
+    mockUseUserStore.mockReturnValue(makeStore("u2", "Grimgork", true));
+  });
+
+  it("navigates to /matches/tournament/:code on successful join", async () => {
+    // First GET: tournament
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ status: "pending", createdBy: "owner1" }),
+    });
+    // POST /join resolves
+    mockPost.mockResolvedValueOnce({ success: true });
+    // Second GET (fetchTournament after join)
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ status: "pending", createdBy: "owner1" }),
+    });
+
+    renderPage();
+
+    const joinBtn = await screen.findByRole("button", { name: /join tournament/i });
+    fireEvent.click(joinBtn);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/tournament/t1/join",
+        expect.objectContaining({ faction: "" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/matches/tournament/ABCDEF");
+    });
+  });
+
+  it("calls fetchTournament again after successful join", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ status: "pending", createdBy: "owner1" }),
+    });
+    mockPost.mockResolvedValueOnce({ success: true });
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ status: "pending", createdBy: "owner1" }),
+    });
+
+    renderPage();
+
+    const joinBtn = await screen.findByRole("button", { name: /join tournament/i });
+    fireEvent.click(joinBtn);
+
+    await waitFor(() => {
+      // mockGet called twice: initial load + after join
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+// ─── handleJoin – error path ──────────────────────────────────────────────────
+
+describe("TournamentViewPage – handleJoin error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore("u2", "Grimgork", true));
+  });
+
+  it("shows joinError in join panel when post rejects", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ status: "pending", createdBy: "owner1" }),
+    });
+    mockPost.mockRejectedValueOnce(new Error("Already full"));
+
+    renderPage();
+
+    const joinBtn = await screen.findByRole("button", { name: /join tournament/i });
+    fireEvent.click(joinBtn);
+
+    await waitFor(() =>
+      expect(screen.getByText("Already full")).toBeInTheDocument(),
+    );
+  });
+});
+
+// ─── Copy tournament code button ──────────────────────────────────────────────
+
+describe("TournamentViewPage – copy tournament code", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore());
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("calls navigator.clipboard.writeText with the tournament code", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ code: "ABCDEF" }),
+    });
+    renderPage();
+
+    await screen.findByText("Test Cup");
+    const copyBtn = screen.getByRole("button", { name: /copy tournament code/i });
+    fireEvent.click(copyBtn);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ABCDEF");
+  });
+
+  it("calls toaster.create after clicking copy button", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ code: "ABCDEF" }),
+    });
+    renderPage();
+
+    await screen.findByText("Test Cup");
+    const copyBtn = screen.getByRole("button", { name: /copy tournament code/i });
+    fireEvent.click(copyBtn);
+
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Copied!" }),
+    );
+  });
+});
+
+// ─── Matches with rounds and W/L badges ──────────────────────────────────────
+
+describe("TournamentViewPage – matches with W/L badges", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore("u2", "Grimgork", true));
+  });
+
+  it("shows round header and 'W' badge when a match has a winner", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        success: true,
+        data: makeTournament({ status: "active" }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [makeMatch({ winnerId: "p1", status: "completed" })],
+      });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/round 1/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText("W")).toBeInTheDocument();
+  });
+
+  it("shows 'L' badge for the losing player", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        success: true,
+        data: makeTournament({ status: "active" }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [makeMatch({ winnerId: "p1", status: "completed" })],
+      });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("L")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'Completed' badge for a completed match", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        success: true,
+        data: makeTournament({ status: "active" }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [makeMatch({ winnerId: "p1", status: "completed" })],
+      });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("Completed")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'In Progress' badge for in_progress match", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        success: true,
+        data: makeTournament({ status: "active" }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [makeMatch({ status: "in_progress" })],
+      });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("In Progress")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'Disputed' badge and dispute text for disputed match", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        success: true,
+        data: makeTournament({ status: "active" }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [makeMatch({ status: "disputed" })],
+      });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/disputed/i).length).toBeGreaterThan(0),
+    );
+    expect(
+      screen.getByText(/result disputed - awaiting organiser/i),
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── champion.faction in banner ───────────────────────────────────────────────
+
+describe("TournamentViewPage – champion faction display", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore("u2", "Grimgork", true));
+  });
+
+  it("shows champion faction in banner when champion has a faction", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        success: true,
+        data: makeTournament({ status: "completed" }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [
+          makeMatch({
+            winnerId: "p1",
+            status: "completed",
+            player1: { participantId: "p1", name: "Grimgork", faction: "Greenskins" },
+            player2: { participantId: "p2", name: "Luthor", faction: "Empire" },
+          }),
+        ],
+      });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/tournament champion/i)).toBeInTheDocument(),
+    );
+    // Faction text appears at least once (may appear in match card too — use getAllByText)
+    expect(screen.getAllByText("Greenskins").length).toBeGreaterThan(0);
+  });
+});
+
+// ─── isAlreadyJoined via username match (no userId) ──────────────────────────
+
+describe("TournamentViewPage – isAlreadyJoined via username match", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+  });
+
+  it("shows 'Participant' badge when participant has no userId but name matches username", async () => {
+    // user.username = "grimgork" (case-insensitive match)
+    mockUseUserStore.mockReturnValue(makeStore("u2", "Grimgork", true));
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({
+        status: "pending",
+        createdBy: "owner1",
+        participants: [
+          {
+            _id: "p1",
+            // no userId — name match via toLowerCase
+            userId: null,
+            name: "grimgork",
+            faction: "",
+          },
+        ],
+      }),
+    });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("Participant")).toBeInTheDocument(),
+    );
+  });
+});
+
+// ─── Back button navigation ───────────────────────────────────────────────────
+
+describe("TournamentViewPage – Back button navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+  });
+
+  it("navigates to /matches/tournament/:code when user is owner", async () => {
+    mockUseUserStore.mockReturnValue(makeStore("owner1", "Owner", true));
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ createdBy: "owner1" }),
+    });
+    renderPage();
+
+    await screen.findByText("Test Cup");
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/matches/tournament/ABCDEF");
+  });
+
+  it("navigates to /matches/tournament/:code when user is participant", async () => {
+    mockUseUserStore.mockReturnValue(makeStore("u2", "Grimgork", true));
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({
+        createdBy: "owner1",
+        participants: [{ _id: "p1", userId: "u2", name: "Grimgork", faction: "" }],
+      }),
+    });
+    renderPage();
+
+    await screen.findByText("Test Cup");
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/matches/tournament/ABCDEF");
+  });
+
+  it("calls navigate(-1) when user is spectator (not owner or participant)", async () => {
+    mockUseUserStore.mockReturnValue(makeStore("u99", "Stranger", false));
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ createdBy: "owner1" }),
+    });
+    renderPage();
+
+    await screen.findByText("Test Cup");
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+});
+
+// ─── bannedFactions display ───────────────────────────────────────────────────
+
+describe("TournamentViewPage – bannedFactions display", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore());
+  });
+
+  it("shows banned factions in the Tournament Info card", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ bannedFactions: ["Greenskins", "Empire"] }),
+    });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("Banned Factions")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Greenskins")).toBeInTheDocument();
+    expect(screen.getByText("Empire")).toBeInTheDocument();
+  });
+});
+
+// ─── joinSuccess state ────────────────────────────────────────────────────────
+
+describe("TournamentViewPage – joinSuccess state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSocket.mockReturnValue(fakeSocket);
+    mockUseUserStore.mockReturnValue(makeStore("u2", "Grimgork", true));
+  });
+
+  it("shows 'You're In!' heading after a successful join", async () => {
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ status: "pending", createdBy: "owner1" }),
+    });
+    mockPost.mockResolvedValueOnce({ success: true });
+    // Second GET after join
+    mockGet.mockResolvedValueOnce({
+      success: true,
+      data: makeTournament({ status: "pending", createdBy: "owner1" }),
+    });
+
+    renderPage();
+
+    const joinBtn = await screen.findByRole("button", { name: /join tournament/i });
+    fireEvent.click(joinBtn);
+
+    // joinSuccess → true before navigation happens
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalled(),
+    );
+
+    // navigate is called (which in real app unmounts, but in test we can check it was called)
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("/matches/tournament/ABCDEF"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds 114 new tests targeting the 5 client-side files with the largest coverage gaps, bringing overall statement coverage from **78.68% → 88.12%**.

### Coverage before and after

| File | Before | After (Stmts) |
|------|--------|----------------|
| `MatchCard.tsx` | 23.8% | 85.71% |
| `MatchesPage.tsx` | 26.55% | 65.9% |
| `authenticationApi.ts` | 39.47% | **100%** |
| `TournamentDetail.tsx` | 40% | 69.52% |
| `TournamentViewPage.tsx` | 72.3% | 83.84% |
| **Overall** | **78.68%** | **88.12%** |

### Tests added (114 total)

**`MatchCardFullCoverage.test.tsx`** (39 tests)
- Admin disputed section: resolve buttons, reported-results map, `onResolveDispute` callbacks
- Admin in-progress reported results display (count label, reporter/winner name resolution)
- Admin Override start button (`onStartOverride`) presence and click
- Participant "waiting for opponent" message (`!isAdmin && isP1/isP2 && myReport`)
- Participant "Result disputed" message
- Override panel: winner selection buttons (`onSetOverrideWinner`), reason input (`onSetOverrideReason`), confirm/disabled state

**`authenticationApiLoginUser.test.ts`** (20 tests)
- `loginUser` success path (PKCE flow, setUser, toast)
- `rememberMe` toast description variant
- State validation passing/failing branches
- Authorization-code exchange path (second POST call, token data merge)
- Missing code-verifier throw
- `success: false` server response (error toast, no setUser)
- HTTP error in catch (re-throw, error toast)
- Token-exchange failure propagation

**`TournamentDetailExtended.test.tsx`** (26 tests)
- `handleCopyCode`: `navigator.clipboard.writeText` called, "Copied!" label, 2s reset
- `handleUpdateDescription`: Save calls `onSaveDescription`, textarea disappears; Cancel hides textarea
- `canAdvance`: Advance Round button shown only when all max-round matches completed; clicking calls `onAdvanceRound`
- Finalize Tournament label for Round Robin type
- Champion banner (completed status with winning match); hidden when no winner
- Tournament Info champion row ("Champion" / "-" states)
- Current Round display (active, non-RoundRobin)
- Admin pencil button opens edit dialog; remove button calls `onRemoveParticipant`

**`TournamentViewPageExtended.test.tsx`** (19 tests)
- `tournament.description` renders via ReactMarkdown
- `handleJoin` success (POST called, navigate to matches URL, re-fetches tournament)
- `handleJoin` error (joinError displayed in join panel)
- Copy tournament code button (`navigator.clipboard.writeText` + toast)
- Matches with rounds: W/L badges, Completed/InProgress/Disputed status badges, disputed dispute text
- Champion faction text in banner
- `isAlreadyJoined` via username match (no `userId`)
- Back button routing (participant/owner → matches URL; spectator → navigate(-1))
- Banned factions list in Tournament Info
- `joinSuccess` state after successful join

**`MatchesPageHandlers.test.tsx`** (14 tests)
- `handleFindByCode`: participant path, spectator path, error path
- `urlCode` auto-select (renders TournamentDetail, calls `fetchMatches`)
- All TournamentDetail handler callbacks: `onBack`, `handleStart`, `handleDelete`, `handleRecordResult`, `handleReportResult`, `handleAdvanceRound` (both completed/non-completed toast), `handleRemoveParticipant`, `handleResolveDispute`
- Socket `emit`/`on` registration when tournament selected

## Lines intentionally not yet covered

The remaining gaps are in more complex UI interaction paths (multi-step dialogs, deep socket event simulation) that will be addressed in subsequent PRs.

## Test plan
- [x] All 114 new tests pass locally
- [x] All 760 existing tests continue to pass (874 total, 0 failures)
- [x] Coverage improves from 78.68% → 88.12% statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hmawiBXCjvYSgqByYtsdo

---
_Generated by [Claude Code](https://claude.ai/code/session_019hmawiBXCjvYSgqByYtsdo)_