### PR TITLE
fix: eliminate white flash on page load

### DIFF
--- a/client-app/index.html
+++ b/client-app/index.html
@@ -27,6 +27,16 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest" />
+  <script>
+    (function () {
+      try {
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.classList.add(theme);
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="/preload.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/client-app/public/preload.css
+++ b/client-app/public/preload.css
@@ -1,3 +1,14 @@
+html,
+body {
+  background-color: #F1ECE1;
+  margin: 0;
+}
+
+html.dark,
+html.dark body {
+  background-color: #100D0A;
+}
+
 .body-hidden {
   display: none;
 }


### PR DESCRIPTION
Fixes #172

Injects a synchronous inline script before preload.css so the correct dark/light class is applied to `<html>` before the first paint. Updates preload.css to set the canvas background colour based on that class, matching the `bg.canvas` semantic token from the Chakra theme.

Generated with [Claude Code](https://claude.ai/code)