### PR TITLE
fix: view ongoing tournaments links broken (#179)

### DIFF
--- a/client-app/src/features/home/components/HeroSection.tsx
+++ b/client-app/src/features/home/components/HeroSection.tsx
@@ -49,7 +49,7 @@ const HeroSection: React.FC = () => {
       </Text>
       <HStack gap={3} justify="center" flexWrap="wrap">
         <Button colorPalette="verdigris" size="lg" asChild>
-          <Link to="/tournaments">View Ongoing Tournaments</Link>
+          <Link to="/tournaments#currentTournaments">View Ongoing Tournaments</Link>
         </Button>
         {showCreateAccount && (
           <Button

--- a/client-app/src/features/home/components/HowItWorksSection.tsx
+++ b/client-app/src/features/home/components/HowItWorksSection.tsx
@@ -81,7 +81,7 @@ const HowItWorksSection: React.FC = () => (
     <Card.Footer>
       <HStack gap={3} flexWrap="wrap">
         <Button colorPalette="verdigris" asChild>
-          <Link to="/tournaments">View Ongoing Tournaments</Link>
+          <Link to="/tournaments#currentTournaments">View Ongoing Tournaments</Link>
         </Button>
         <Button
           variant="outline"

--- a/client-app/src/features/home/components/TournamentLookup.tsx
+++ b/client-app/src/features/home/components/TournamentLookup.tsx
@@ -208,7 +208,7 @@ const TournamentLookup: React.FC = () => {
                 </VStack>
                 {activeTournaments.length > 6 && (
                   <Button variant="ghost" size="sm" mt={2} asChild>
-                    <Link to="/tournaments">View all tournaments</Link>
+                    <Link to="/tournaments#currentTournaments">View all tournaments</Link>
                   </Button>
                 )}
               </Box>

--- a/client-app/src/tests/features/home/HeroSection.test.tsx
+++ b/client-app/src/tests/features/home/HeroSection.test.tsx
@@ -86,11 +86,11 @@ describe("HeroSection", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("View Ongoing Tournaments link points to /tournaments", () => {
+  it("View Ongoing Tournaments link points to /tournaments#currentTournaments", () => {
     renderHero();
     const link = screen.getByRole("link", {
       name: /View Ongoing Tournaments/i,
     });
-    expect(link).toHaveAttribute("href", "/tournaments");
+    expect(link).toHaveAttribute("href", "/tournaments#currentTournaments");
   });
 });

--- a/client-app/src/tests/features/home/HowItWorksSection.test.tsx
+++ b/client-app/src/tests/features/home/HowItWorksSection.test.tsx
@@ -95,11 +95,11 @@ describe("HowItWorksSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("View Ongoing Tournaments link points to /tournaments", () => {
+  it("View Ongoing Tournaments link points to /tournaments#currentTournaments", () => {
     renderSection();
     const link = screen.getByRole("link", {
       name: /View Ongoing Tournaments/i,
     });
-    expect(link).toHaveAttribute("href", "/tournaments");
+    expect(link).toHaveAttribute("href", "/tournaments#currentTournaments");
   });
 });


### PR DESCRIPTION
Fixes #179

Links on the home page pointing to "View Ongoing Tournaments" were navigating to `/tournaments` without a hash fragment. Since `TournamentsPage` uses URL hash-based tab routing, users landed on the default "Create a Simple Bracket" tab instead of the ongoing tournaments view.

Updated all three affected links to `/tournaments#currentTournaments`:
- `HeroSection.tsx`
- `HowItWorksSection.tsx`
- `TournamentLookup.tsx`

Generated with [Claude Code](https://claude.ai/code)