### PR TITLE
fix: clear stale CSRF token on login/logout to prevent 403s after account switching

### DIFF
--- a/client-app/src/core/api/httpClient.ts
+++ b/client-app/src/core/api/httpClient.ts
@@ -159,14 +159,18 @@ class HttpClient {
     });
 
     if (response.status === 403) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let errorData: any = null;
       try {
-        const errorData = await response.json();
+        errorData = await response.json();
+      } catch {
+        // body unparseable — fall through to handleResponse
+      }
 
+      if (errorData !== null) {
         if (errorData.error === "CSRF validation failed") {
           this.csrfToken = null;
-
           token = await this.ensureCsrfToken();
-
           if (token) {
             const retryResponse = await fetch(url, {
               method: "POST",
@@ -179,14 +183,16 @@ class HttpClient {
               },
               body: data ? JSON.stringify(data) : undefined,
             });
-
             return this.handleResponse<T>(retryResponse);
-          } else {
-            throw new Error("Could not refresh CSRF token after failure");
           }
+          throw new Error(
+            errorData.message || "Could not refresh CSRF token after failure",
+          );
         }
-      } catch (e) {
-        console.error("Error handling CSRF retry:", e);
+        // Non-CSRF 403 — body already consumed, throw with the message we read.
+        throw new Error(
+          errorData.message || `Error ${response.status}: ${response.statusText}`,
+        );
       }
     }
 
@@ -228,14 +234,18 @@ class HttpClient {
     });
 
     if (response.status === 403) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let errorData: any = null;
       try {
-        const errorData = await response.json();
+        errorData = await response.json();
+      } catch {
+        // body unparseable — fall through to handleResponse
+      }
 
+      if (errorData !== null) {
         if (errorData.error === "CSRF validation failed") {
           this.csrfToken = null;
-
           token = await this.ensureCsrfToken();
-
           if (token) {
             const retryResponse = await fetch(url, {
               method: "PUT",
@@ -248,14 +258,15 @@ class HttpClient {
               },
               body: data ? JSON.stringify(data) : undefined,
             });
-
             return this.handleResponse<T>(retryResponse);
-          } else {
-            throw new Error("Could not refresh CSRF token after failure");
           }
+          throw new Error(
+            errorData.message || "Could not refresh CSRF token after failure",
+          );
         }
-      } catch (e) {
-        console.error("Error handling CSRF retry:", e);
+        throw new Error(
+          errorData.message || `Error ${response.status}: ${response.statusText}`,
+        );
       }
     }
 
@@ -297,14 +308,18 @@ class HttpClient {
     });
 
     if (response.status === 403) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let errorData: any = null;
       try {
-        const errorData = await response.json();
+        errorData = await response.json();
+      } catch {
+        // body unparseable — fall through to handleResponse
+      }
 
+      if (errorData !== null) {
         if (errorData.error === "CSRF validation failed") {
           this.csrfToken = null;
-
           token = await this.ensureCsrfToken();
-
           if (token) {
             const retryResponse = await fetch(url, {
               method: "PATCH",
@@ -317,14 +332,15 @@ class HttpClient {
               },
               body: data ? JSON.stringify(data) : undefined,
             });
-
             return this.handleResponse<T>(retryResponse);
-          } else {
-            throw new Error("Could not refresh CSRF token after failure");
           }
+          throw new Error(
+            errorData.message || "Could not refresh CSRF token after failure",
+          );
         }
-      } catch (e) {
-        console.error("Error handling CSRF retry:", e);
+        throw new Error(
+          errorData.message || `Error ${response.status}: ${response.statusText}`,
+        );
       }
     }
 
@@ -361,14 +377,18 @@ class HttpClient {
     });
 
     if (response.status === 403) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let errorData: any = null;
       try {
-        const errorData = await response.json();
+        errorData = await response.json();
+      } catch {
+        // body unparseable — fall through to handleResponse
+      }
 
+      if (errorData !== null) {
         if (errorData.error === "CSRF validation failed") {
           this.csrfToken = null;
-
           token = await this.ensureCsrfToken();
-
           if (token) {
             const retryResponse = await fetch(url, {
               method: "DELETE",
@@ -380,14 +400,15 @@ class HttpClient {
                 ...requestOptions.headers,
               },
             });
-
             return this.handleResponse<T>(retryResponse);
-          } else {
-            throw new Error("Could not refresh CSRF token after failure");
           }
+          throw new Error(
+            errorData.message || "Could not refresh CSRF token after failure",
+          );
         }
-      } catch (e) {
-        console.error("Error handling CSRF retry:", e);
+        throw new Error(
+          errorData.message || `Error ${response.status}: ${response.statusText}`,
+        );
       }
     }
 

--- a/client-app/src/features/authentication/api/authenticationApi.ts
+++ b/client-app/src/features/authentication/api/authenticationApi.ts
@@ -84,6 +84,10 @@ export const loginUser = async (data: LoginData): Promise<LoginResponse> => {
         isGuest: false,
       });
 
+      // The new session has a different session ID (Passport regenerates on login),
+      // so any cached CSRF token from the previous session is now invalid.
+      httpClient.resetCsrfToken();
+
       toaster.create({
         title: `Successfully logged in as ${
           responseData.data?.username ||
@@ -151,6 +155,9 @@ export const logoutUser = async (): Promise<{
     // Always clear the local user state, even if server response fails
     const { clearUser } = useUserStore.getState();
     clearUser();
+    // The server session is now destroyed; clear the cached CSRF token so the
+    // next user to log in gets a fresh one for their new session.
+    httpClient.resetCsrfToken();
 
     if (response.success) {
       toaster.create({
@@ -165,6 +172,7 @@ export const logoutUser = async (): Promise<{
     // Still clear the user state even on error
     const { clearUser } = useUserStore.getState();
     clearUser();
+    httpClient.resetCsrfToken();
 
     toaster.create({
       title: "Logout Issue",

--- a/client-app/src/tests/features/authentication/authenticationApi.test.ts
+++ b/client-app/src/tests/features/authentication/authenticationApi.test.ts
@@ -6,14 +6,16 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockPost, mockClearUser, mockToasterCreate } = vi.hoisted(() => ({
-  mockPost: vi.fn(),
-  mockClearUser: vi.fn(),
-  mockToasterCreate: vi.fn(),
-}));
+const { mockPost, mockClearUser, mockToasterCreate, mockResetCsrfToken } =
+  vi.hoisted(() => ({
+    mockPost: vi.fn(),
+    mockClearUser: vi.fn(),
+    mockToasterCreate: vi.fn(),
+    mockResetCsrfToken: vi.fn(),
+  }));
 
 vi.mock("@/core/api/httpClient", () => ({
-  httpClient: { post: mockPost },
+  httpClient: { post: mockPost, resetCsrfToken: mockResetCsrfToken },
 }));
 
 vi.mock("@/shared/stores/userStore", () => ({
@@ -41,6 +43,7 @@ describe("logoutUser – success path (response.success=true)", () => {
     mockPost.mockResolvedValueOnce({ success: true, message: "logged out" });
     const result = await logoutUser();
     expect(mockClearUser).toHaveBeenCalled();
+    expect(mockResetCsrfToken).toHaveBeenCalled();
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ type: "success" }),
     );
@@ -69,6 +72,7 @@ describe("logoutUser – catch path", () => {
     mockPost.mockRejectedValueOnce(new Error("Server down"));
     const result = await logoutUser();
     expect(mockClearUser).toHaveBeenCalled();
+    expect(mockResetCsrfToken).toHaveBeenCalled();
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ type: "warning" }),
     );

--- a/client-app/src/tests/features/authentication/authenticationApiLoginUser.test.ts
+++ b/client-app/src/tests/features/authentication/authenticationApiLoginUser.test.ts
@@ -20,6 +20,7 @@ const {
   mockInitiatePKCEFlow,
   mockVerifyAuthState,
   mockGetAndClearCodeVerifier,
+  mockResetCsrfToken,
 } = vi.hoisted(() => ({
   mockPost: vi.fn(),
   mockSetUser: vi.fn(),
@@ -28,10 +29,11 @@ const {
   mockInitiatePKCEFlow: vi.fn(),
   mockVerifyAuthState: vi.fn(),
   mockGetAndClearCodeVerifier: vi.fn(),
+  mockResetCsrfToken: vi.fn(),
 }));
 
 vi.mock("@/core/api/httpClient", () => ({
-  httpClient: { post: mockPost },
+  httpClient: { post: mockPost, resetCsrfToken: mockResetCsrfToken },
 }));
 
 vi.mock("@/shared/stores/userStore", () => ({
@@ -92,6 +94,7 @@ describe("loginUser – success path (no authorizationCode, no state in response
         isGuest: false,
       }),
     );
+    expect(mockResetCsrfToken).toHaveBeenCalled();
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ type: "success" }),
     );

--- a/server-app/src/interfaces/http/middleware/csrf-middleware.js
+++ b/server-app/src/interfaces/http/middleware/csrf-middleware.js
@@ -79,6 +79,7 @@ const csrfErrorHandler = (err, req, res, next) => {
     });
     return res.status(403).json({
       success: false,
+      error: "CSRF validation failed",
       message: "Invalid or missing CSRF token",
     });
   }


### PR DESCRIPTION
Fixes #145

**Root cause:** Passport regenerates the session on login (session fixation prevention), invalidating any CSRF token cached from the previous session. Switching accounts without clearing the token cache caused every subsequent mutation to fail with 403 until a hard refresh re-initialised the HttpClient singleton.

**Three fixes:**
1. Call `httpClient.resetCsrfToken()` in `logoutUser()` and `loginUser()` after successful login to force a fresh CSRF token for the new session.
2. Add `error: "CSRF validation failed"` to the server CSRF 403 response so the client retry logic actually triggers in production.
3. Restructure the 403 handler in post/put/patch/delete to read the response body exactly once, eliminating a double body-read bug.

Generated with [Claude Code](https://claude.ai/code)