### PR TITLE
fix(tests): update link assertions for #currentTournaments hash route

### DIFF
--- a/client-app/src/tests/features/home/HeroSection.test.tsx
+++ b/client-app/src/tests/features/home/HeroSection.test.tsx
@@ -86,11 +86,11 @@ describe("HeroSection", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("View Ongoing Tournaments link points to /tournaments", () => {
+  it("View Ongoing Tournaments link points to /tournaments#currentTournaments", () => {
     renderHero();
     const link = screen.getByRole("link", {
       name: /View Ongoing Tournaments/i,
     });
-    expect(link).toHaveAttribute("href", "/tournaments");
+    expect(link).toHaveAttribute("href", "/tournaments#currentTournaments");
   });
 });

--- a/client-app/src/tests/features/home/HowItWorksSection.test.tsx
+++ b/client-app/src/tests/features/home/HowItWorksSection.test.tsx
@@ -95,11 +95,11 @@ describe("HowItWorksSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("View Ongoing Tournaments link points to /tournaments", () => {
+  it("View Ongoing Tournaments link points to /tournaments#currentTournaments", () => {
     renderSection();
     const link = screen.getByRole("link", {
       name: /View Ongoing Tournaments/i,
     });
-    expect(link).toHaveAttribute("href", "/tournaments");
+    expect(link).toHaveAttribute("href", "/tournaments#currentTournaments");
   });
 });


### PR DESCRIPTION
## Summary

- Updates `HeroSection.test.tsx` and `HowItWorksSection.test.tsx` to assert `href="/tournaments#currentTournaments"` instead of the old `href="/tournaments"`
- Fixes the 2 failing client tests introduced when issue #179 updated the "View Ongoing Tournaments" links to deep-link to the correct tab

## Test plan

- [x] `npx vitest run src/tests/features/home/HeroSection.test.tsx` passes
- [x] `npx vitest run src/tests/features/home/HowItWorksSection.test.tsx` passes
- [x] All 533 server tests pass (`npm run test --workspace=server-app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4CUJPsxHPtqXsDvHaBZK9

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4CUJPsxHPtqXsDvHaBZK9)_