### PR TITLE
fix(caddy): trust Cloudflare IP ranges and add HSTS

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -7,7 +7,7 @@
         format json
     }
     servers {
-        trusted_proxies static private_ranges
+        trusted_proxies static private_ranges 173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20 197.234.240.0/22 172.64.0.0/13 104.16.0.0/13 104.24.0.0/14 162.158.0.0/15 198.41.128.0/17 131.0.72.0/22 2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32 2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
     }
 }
 
@@ -33,6 +33,7 @@
     header {
         X-Content-Type-Options "nosniff"
         X-Frame-Options "SAMEORIGIN"
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
         Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
         Cross-Origin-Opener-Policy "same-origin"
         Cross-Origin-Embedder-Policy "credentialless"


### PR DESCRIPTION
## Summary

- **`trusted_proxies`**: Added all Cloudflare IPv4 and IPv6 edge ranges alongside the existing `private_ranges`. Without this, Caddy ignored Cloudflare's `X-Forwarded-For` header and treated every request as coming from a Cloudflare edge IP — breaking real-IP logging and rate limiting.
- **`Strict-Transport-Security`**: Added `max-age=31536000; includeSubDomains` now that Cloudflare is enforcing HTTPS end-to-end.

`private_ranges` is kept so the local Docker Compose dev stack (no Cloudflare) continues to work without changes.

## Test plan

- [x] Deploy to Railway and confirm access logs show real client IPs (not Cloudflare edge IPs)
- [x] Verify rate limiting applies per real client IP, not per Cloudflare IP
- [x] Check response headers include `Strict-Transport-Security`
- [x] Confirm local `docker-compose up` still works (no Cloudflare in the path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEFjNZetjhzsYNe38shggQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEFjNZetjhzsYNe38shggQ)_