### PR TITLE
test: close branch-coverage gaps in auth/account API modules

### DIFF
--- a/client-app/src/tests/features/account/accountApi.test.ts
+++ b/client-app/src/tests/features/account/accountApi.test.ts
@@ -40,7 +40,10 @@ const {
     mockPost: vi.fn(),
     mockDelete: vi.fn(),
     mockCheckSessionStatus: vi.fn(),
-    mockGetState: vi.fn(() => ({ setUser: mockSetUser, clearUser: mockClearUser })),
+    mockGetState: vi.fn(() => ({
+      setUser: mockSetUser,
+      clearUser: mockClearUser,
+    })),
     mockSetUser,
     mockClearUser,
     mockToasterCreate: vi.fn(),
@@ -142,11 +145,27 @@ describe("updateUsername", () => {
     );
   });
 
+  it("falls back to the passed-in username when responseData.data is absent", async () => {
+    mockPost.mockResolvedValueOnce({ success: true, message: "ok" });
+    await updateUsername("FallbackName");
+    expect(mockSetUser).toHaveBeenCalledWith({ username: "FallbackName" });
+  });
+
+  it("throws the default message when responseData.success=false and message is absent", async () => {
+    mockPost.mockResolvedValueOnce({ success: false });
+    await expect(updateUsername("x")).rejects.toThrow(
+      "Failed to update username",
+    );
+  });
+
   it("toaster shows Error.message on Error throw from post", async () => {
     mockPost.mockRejectedValueOnce(new Error("Connection refused"));
     await expect(updateUsername("x")).rejects.toThrow();
     expect(mockToasterCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ description: "Connection refused", type: "error" }),
+      expect.objectContaining({
+        description: "Connection refused",
+        type: "error",
+      }),
     );
   });
 
@@ -154,7 +173,10 @@ describe("updateUsername", () => {
     mockPost.mockRejectedValueOnce("some string error");
     await expect(updateUsername("x")).rejects.toThrow();
     expect(mockToasterCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ description: "An error occurred", type: "error" }),
+      expect.objectContaining({
+        description: "An error occurred",
+        type: "error",
+      }),
     );
   });
 });
@@ -172,8 +194,16 @@ describe("deleteAccount", () => {
   });
 
   it("throws when responseData.success=false", async () => {
-    mockDelete.mockResolvedValueOnce({ success: false, message: "Cannot delete" });
+    mockDelete.mockResolvedValueOnce({
+      success: false,
+      message: "Cannot delete",
+    });
     await expect(deleteAccount()).rejects.toThrow("Cannot delete");
+  });
+
+  it("throws the default message when responseData.success=false and message is absent", async () => {
+    mockDelete.mockResolvedValueOnce({ success: false });
+    await expect(deleteAccount()).rejects.toThrow("Failed to delete account");
   });
 
   it("toaster shows error on catch", async () => {
@@ -181,6 +211,17 @@ describe("deleteAccount", () => {
     await expect(deleteAccount()).rejects.toThrow();
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error" }),
+    );
+  });
+
+  it("toaster shows 'An error occurred' on non-Error throw", async () => {
+    mockDelete.mockRejectedValueOnce("some string error");
+    await expect(deleteAccount()).rejects.toBe("some string error");
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "An error occurred",
+        type: "error",
+      }),
     );
   });
 });
@@ -203,8 +244,18 @@ describe("updatePassword", () => {
   });
 
   it("throws when responseData.success=false", async () => {
-    mockPost.mockResolvedValueOnce({ success: false, message: "Wrong password" });
+    mockPost.mockResolvedValueOnce({
+      success: false,
+      message: "Wrong password",
+    });
     await expect(updatePassword(pwData)).rejects.toThrow("Wrong password");
+  });
+
+  it("throws the default message when responseData.success=false and message is absent", async () => {
+    mockPost.mockResolvedValueOnce({ success: false });
+    await expect(updatePassword(pwData)).rejects.toThrow(
+      "Failed to update password",
+    );
   });
 
   it("toaster shows Error.message on Error throw", async () => {
@@ -219,7 +270,10 @@ describe("updatePassword", () => {
     mockPost.mockRejectedValueOnce(42);
     await expect(updatePassword(pwData)).rejects.toThrow();
     expect(mockToasterCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ description: "An error occurred", type: "error" }),
+      expect.objectContaining({
+        description: "An error occurred",
+        type: "error",
+      }),
     );
   });
 });

--- a/client-app/src/tests/features/authentication/authenticationApiLoginUser.test.ts
+++ b/client-app/src/tests/features/authentication/authenticationApiLoginUser.test.ts
@@ -68,7 +68,10 @@ import { loginUser } from "@/features/authentication/api/authenticationApi";
 
 // Helper defaults
 const defaultPKCE = { codeChallenge: "challenge123", state: "state-abc" };
-const baseLoginData = { identifier: "grimgork@waaagh.com", password: "Waaagh1!" };
+const baseLoginData = {
+  identifier: "grimgork@waaagh.com",
+  password: "Waaagh1!",
+};
 
 describe("loginUser – success path (no authorizationCode, no state in response)", () => {
   beforeEach(() => {
@@ -132,6 +135,59 @@ describe("loginUser – success path (no authorizationCode, no state in response
   });
 });
 
+describe("loginUser – success path with falsy user fields", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitiatePKCEFlow.mockResolvedValue(defaultPKCE);
+  });
+
+  it("falls back to empty strings for id/email/username when data fields are absent", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: {},
+    });
+
+    await loginUser(baseLoginData);
+
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "", email: "", username: "" }),
+    );
+  });
+
+  it("uses the response email in the success toast title when username is absent", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: { id: "u1", email: "g@g.com" },
+    });
+
+    await loginUser(baseLoginData);
+
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Successfully logged in as g@g.com",
+      }),
+    );
+  });
+
+  it("uses the submitted identifier in the success toast title when username and email are absent", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      message: "ok",
+      data: {},
+    });
+
+    await loginUser(baseLoginData);
+
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: `Successfully logged in as ${baseLoginData.identifier}`,
+      }),
+    );
+  });
+});
+
 describe("loginUser – success path with rememberMe=true", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -184,7 +240,12 @@ describe("loginUser – success path with state validation passing", () => {
     mockPost.mockResolvedValueOnce({
       success: true,
       message: "ok",
-      data: { id: "u1", email: "g@g.com", username: "Grimgork", state: "state-abc" },
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        state: "state-abc",
+      },
     });
 
     await expect(loginUser(baseLoginData)).resolves.toBeDefined();
@@ -203,7 +264,12 @@ describe("loginUser – state validation failing", () => {
     mockPost.mockResolvedValueOnce({
       success: true,
       message: "ok",
-      data: { id: "u1", email: "g@g.com", username: "Grimgork", state: "tampered-state" },
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        state: "tampered-state",
+      },
     });
 
     await expect(loginUser(baseLoginData)).rejects.toThrow(
@@ -216,7 +282,12 @@ describe("loginUser – state validation failing", () => {
     mockPost.mockResolvedValueOnce({
       success: true,
       message: "ok",
-      data: { id: "u1", email: "g@g.com", username: "Grimgork", state: "bad-state" },
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        state: "bad-state",
+      },
     });
 
     await loginUser(baseLoginData).catch(() => {});
@@ -249,7 +320,12 @@ describe("loginUser – authorizationCode + codeVerifier found", () => {
     mockPost.mockResolvedValueOnce({
       success: true,
       message: "token ok",
-      data: { id: "u1", email: "g@g.com", username: "Grimgork", expiresAt: 9999 },
+      data: {
+        id: "u1",
+        email: "g@g.com",
+        username: "Grimgork",
+        expiresAt: 9999,
+      },
     });
 
     await loginUser(baseLoginData);
@@ -350,6 +426,18 @@ describe("loginUser – responseData.success = false", () => {
       expect.objectContaining({ description: "Account locked" }),
     );
   });
+
+  it("uses the default description when the server provides no message", async () => {
+    mockPost.mockResolvedValueOnce({ success: false });
+
+    await loginUser(baseLoginData);
+
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "Invalid credentials or server error",
+      }),
+    );
+  });
 });
 
 describe("loginUser – httpClient.post throws", () => {
@@ -418,7 +506,9 @@ describe("loginUser – exchangeCodeForToken internal error", () => {
     // Second post (token exchange) fails
     mockPost.mockRejectedValueOnce(new Error("Token exchange failed"));
 
-    await expect(loginUser(baseLoginData)).rejects.toThrow("Token exchange failed");
+    await expect(loginUser(baseLoginData)).rejects.toThrow(
+      "Token exchange failed",
+    );
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Login Failed", type: "error" }),
     );

--- a/client-app/src/tests/features/authentication/guestApi.test.ts
+++ b/client-app/src/tests/features/authentication/guestApi.test.ts
@@ -30,7 +30,10 @@ vi.mock("@/shared/ui/Toaster", () => ({
   toaster: { create: mockToasterCreate },
 }));
 
-import { createGuestUser, updateGuestUsername } from "@/features/authentication/api/guestApi";
+import {
+  createGuestUser,
+  updateGuestUsername,
+} from "@/features/authentication/api/guestApi";
 
 describe("createGuestUser", () => {
   beforeEach(() => {
@@ -41,12 +44,22 @@ describe("createGuestUser", () => {
     const futureTime = Date.now() + 1000;
     mockPost.mockResolvedValueOnce({
       success: true,
-      data: { id: "u1", username: "g1", email: "", isGuest: true, expiresAt: futureTime },
+      data: {
+        id: "u1",
+        username: "g1",
+        email: "",
+        isGuest: true,
+        expiresAt: futureTime,
+      },
     });
     const result = await createGuestUser();
     expect(result.success).toBe(true);
-    expect(mockSetUser).toHaveBeenCalledWith(expect.objectContaining({ expiresAt: futureTime }));
-    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "success" }));
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresAt: futureTime }),
+    );
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
   });
 
   it("falls back to 48h default when expiresAt is missing (line 28 false)", async () => {
@@ -57,20 +70,46 @@ describe("createGuestUser", () => {
     });
     await createGuestUser();
     const callArg = mockSetUser.mock.calls[0][0];
-    expect(callArg.expiresAt).toBeGreaterThanOrEqual(before + 48 * 3600 * 1000 - 100);
+    expect(callArg.expiresAt).toBeGreaterThanOrEqual(
+      before + 48 * 3600 * 1000 - 100,
+    );
+  });
+
+  it("falls back to empty strings when id and username are absent", async () => {
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: {
+        id: "",
+        username: "",
+        email: "",
+        isGuest: true,
+        expiresAt: Date.now() + 1000,
+      },
+    });
+    await createGuestUser();
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "", username: "", email: "" }),
+    );
   });
 
   it("throws when success=false (line 47 else branch)", async () => {
     mockPost.mockResolvedValueOnce({ success: false, message: "no" });
-    await expect(createGuestUser()).rejects.toThrow("Failed to create guest user account");
-    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+    await expect(createGuestUser()).rejects.toThrow(
+      "Failed to create guest user account",
+    );
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
   });
 
   it("uses error.message in toast for Error instance in catch (line 55 true)", async () => {
     mockPost.mockRejectedValueOnce(new Error("Network failure"));
     await expect(createGuestUser()).rejects.toThrow("Network failure");
     expect(mockToasterCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ description: "Network failure", type: "error" }),
+      expect.objectContaining({
+        description: "Network failure",
+        type: "error",
+      }),
     );
   });
 
@@ -78,7 +117,10 @@ describe("createGuestUser", () => {
     mockPost.mockRejectedValueOnce("plain string error");
     await expect(createGuestUser()).rejects.toBe("plain string error");
     expect(mockToasterCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ description: "An error occurred", type: "error" }),
+      expect.objectContaining({
+        description: "An error occurred",
+        type: "error",
+      }),
     );
   });
 });
@@ -96,7 +138,9 @@ describe("updateGuestUsername", () => {
     const result = await updateGuestUsername("newname");
     expect(result.success).toBe(true);
     expect(mockSetUser).toHaveBeenCalledWith({ username: "newname" });
-    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "success" }));
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
   });
 
   it("throws when success=false (else branch)", async () => {
@@ -104,12 +148,16 @@ describe("updateGuestUsername", () => {
     await expect(updateGuestUsername("x")).rejects.toThrow(
       "Failed to update guest user account",
     );
-    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
   });
 
   it("uses error.message in toast for Error instance in catch", async () => {
     mockPost.mockRejectedValueOnce(new Error("Username taken"));
-    await expect(updateGuestUsername("taken")).rejects.toThrow("Username taken");
+    await expect(updateGuestUsername("taken")).rejects.toThrow(
+      "Username taken",
+    );
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ description: "Username taken", type: "error" }),
     );
@@ -119,7 +167,10 @@ describe("updateGuestUsername", () => {
     mockPost.mockRejectedValueOnce(42);
     await expect(updateGuestUsername("x")).rejects.toBe(42);
     expect(mockToasterCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ description: "An error occurred", type: "error" }),
+      expect.objectContaining({
+        description: "An error occurred",
+        type: "error",
+      }),
     );
   });
 });

--- a/client-app/src/tests/features/authentication/passwordResetApi.test.ts
+++ b/client-app/src/tests/features/authentication/passwordResetApi.test.ts
@@ -46,8 +46,13 @@ describe("requestPasswordReset", () => {
   });
 
   it("throws and shows error toast when success=false (else branch)", async () => {
-    mockPost.mockResolvedValueOnce({ success: false, message: "No user found" });
-    await expect(requestPasswordReset("x@y.com")).rejects.toThrow("No user found");
+    mockPost.mockResolvedValueOnce({
+      success: false,
+      message: "No user found",
+    });
+    await expect(requestPasswordReset("x@y.com")).rejects.toThrow(
+      "No user found",
+    );
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", description: "No user found" }),
     );
@@ -55,7 +60,9 @@ describe("requestPasswordReset", () => {
 
   it("shows generic error description for non-Error in catch (line 46 false)", async () => {
     mockPost.mockRejectedValueOnce("network glitch");
-    await expect(requestPasswordReset("x@y.com")).rejects.toBe("network glitch");
+    await expect(requestPasswordReset("x@y.com")).rejects.toBe(
+      "network glitch",
+    );
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "error",
@@ -64,13 +71,23 @@ describe("requestPasswordReset", () => {
       }),
     );
   });
+
+  it("throws the default message when success=false and message is absent (line 37 fallback)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false });
+    await expect(requestPasswordReset("x@y.com")).rejects.toThrow(
+      "Failed to send password reset email",
+    );
+  });
 });
 
 describe("verifyResetToken", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("returns response without showing a toast on success", async () => {
-    mockPost.mockResolvedValueOnce({ success: true, data: { userId: "u1", validUntil: 9999 } });
+    mockPost.mockResolvedValueOnce({
+      success: true,
+      data: { userId: "u1", validUntil: 9999 },
+    });
     const result = await verifyResetToken("tok123");
     expect(result.success).toBe(true);
     expect(result.data?.userId).toBe("u1");
@@ -99,8 +116,13 @@ describe("resetPassword", () => {
   });
 
   it("throws and shows error toast with message when success=false (Error instance)", async () => {
-    mockPost.mockResolvedValueOnce({ success: false, message: "Token invalid" });
-    await expect(resetPassword("bad-tok", "newpass")).rejects.toThrow("Token invalid");
+    mockPost.mockResolvedValueOnce({
+      success: false,
+      message: "Token invalid",
+    });
+    await expect(resetPassword("bad-tok", "newpass")).rejects.toThrow(
+      "Token invalid",
+    );
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", description: "Token invalid" }),
     );
@@ -112,8 +134,16 @@ describe("resetPassword", () => {
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "error",
-        description: "There was an error resetting your password. Please try again.",
+        description:
+          "There was an error resetting your password. Please try again.",
       }),
+    );
+  });
+
+  it("throws the default message when success=false and message is absent (line 103 fallback)", async () => {
+    mockPost.mockResolvedValueOnce({ success: false });
+    await expect(resetPassword("tok", "newpass")).rejects.toThrow(
+      "Failed to reset password",
     );
   });
 });

--- a/client-app/src/tests/features/authentication/registrationApi.test.ts
+++ b/client-app/src/tests/features/authentication/registrationApi.test.ts
@@ -13,13 +13,14 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockPost, mockGet, mockSetUser, mockToasterCreate, mockLoginUser } = vi.hoisted(() => ({
-  mockPost: vi.fn(),
-  mockGet: vi.fn(),
-  mockSetUser: vi.fn(),
-  mockToasterCreate: vi.fn(),
-  mockLoginUser: vi.fn(),
-}));
+const { mockPost, mockGet, mockSetUser, mockToasterCreate, mockLoginUser } =
+  vi.hoisted(() => ({
+    mockPost: vi.fn(),
+    mockGet: vi.fn(),
+    mockSetUser: vi.fn(),
+    mockToasterCreate: vi.fn(),
+    mockLoginUser: vi.fn(),
+  }));
 
 vi.mock("@/core/api/httpClient", () => ({
   httpClient: { post: mockPost, get: mockGet },
@@ -37,7 +38,10 @@ vi.mock("@/features/authentication/api/authenticationApi", () => ({
   loginUser: mockLoginUser,
 }));
 
-import { registerUser, userExists } from "@/features/authentication/api/registrationApi";
+import {
+  registerUser,
+  userExists,
+} from "@/features/authentication/api/registrationApi";
 
 describe("registerUser", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -58,7 +62,9 @@ describe("registerUser", () => {
       identifier: "g@g.com",
       password: "hunter123",
     });
-    expect(mockToasterCreate).toHaveBeenCalledWith(expect.objectContaining({ type: "success" }));
+    expect(mockToasterCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
   });
 
   it("sets user directly when no password is provided (line 43 else branch)", async () => {
@@ -73,13 +79,29 @@ describe("registerUser", () => {
     );
   });
 
+  it("falls back to an empty id when responseData.data is absent (line 48 fallback)", async () => {
+    mockPost.mockResolvedValueOnce({ success: true });
+    await registerUser({ username: "NoData", email: "nd@g.com" });
+    expect(mockSetUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "",
+        username: "NoData",
+        email: "nd@g.com",
+      }),
+    );
+  });
+
   it("shows warning toast when auto-login throws (inner catch line 54)", async () => {
     mockPost.mockResolvedValueOnce({
       success: true,
       data: { id: "u3", username: "AutoFail", email: "af@g.com" },
     });
     mockLoginUser.mockRejectedValueOnce(new Error("Login error"));
-    await registerUser({ username: "AutoFail", email: "af@g.com", password: "pass1234" });
+    await registerUser({
+      username: "AutoFail",
+      email: "af@g.com",
+      password: "pass1234",
+    });
     expect(mockToasterCreate).toHaveBeenCalledWith(
       expect.objectContaining({ type: "warning" }),
     );


### PR DESCRIPTION
## Summary

Part of an ongoing effort to reach 100% unit test coverage. This PR covers 5 files (client-app API modules under `src/features/*/api/`):

- `accountApi.ts`
- `authenticationApi.ts`
- `guestApi.ts`
- `passwordResetApi.ts`
- `registrationApi.ts`

These files already had extensive tests for their happy-path/error-path logic, but were missing coverage of a handful of small fallback branches: default error messages (`response.message || "..."`), `id`/`email`/`username || ""` fallbacks when optional response fields are absent, and one missing non-`Error` catch case.

### Coverage before/after (scoped to these 5 files)

| Metric | Before | After |
|---|---|---|
| Statements | 100% | 100% |
| Branches | ~80% (varied per file) | **100%** |
| Functions | 100% | 100% |
| Lines | 100% | 100% |

Full scoped run: `Statements 100% (153/153)`, `Branches 100% (87/87)`, `Functions 100% (15/15)`, `Lines 100% (153/153)`.

### Tests added

13 new test cases across the 5 existing spec files (no new files created — extended existing suites to keep assertions colocated with their existing branch-coverage comments). Total client test count: 963 → 976, all passing.

### Intentionally excluded

Nothing excluded in this PR — no lines were found to be genuinely unreachable in these 5 files.

## Test plan

- [x] `npx vitest run` — all 976 client tests pass
- [x] `npx vitest run --coverage` scoped to the 5 changed source files — 100% statements/branches/functions/lines
- [x] `npx eslint` on the changed test files — no errors
- [x] `npx prettier --write` applied to changed test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wuwkYpsy38PaisGqiKqqi


---
_Generated by [Claude Code](https://claude.ai/code/session_019wuwkYpsy38PaisGqiKqqi)_