### PR TITLE
fix: flaky faction-select assertion in EditParticipantDialog test

### DIFF
--- a/client-app/src/tests/features/matches/EditParticipantDialogInteraction.test.tsx
+++ b/client-app/src/tests/features/matches/EditParticipantDialogInteraction.test.tsx
@@ -85,8 +85,10 @@ describe("EditParticipantDialog – Select onValueChange triggers onParticipantC
     const empirOption = options.find((o) => o.textContent?.includes("Empire"));
     if (empirOption) {
       await user.click(empirOption);
-      expect(onParticipantChange).toHaveBeenCalledWith(
-        expect.objectContaining({ faction: "Empire" }),
+      await waitFor(() =>
+        expect(onParticipantChange).toHaveBeenCalledWith(
+          expect.objectContaining({ faction: "Empire" }),
+        ),
       );
     } else {
       // If we can't find Empire, just verify some option was available
@@ -101,6 +103,7 @@ describe("EditParticipantDialog – onOpenChange(e.open=false) calls onClose", (
     const onClose = vi.fn();
     renderDialog({ onClose });
 
+    await screen.findByRole("dialog");
     await user.keyboard("{Escape}");
 
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));


### PR DESCRIPTION
## Summary

The `Client Vitest Tests` CI run on `main` (triggered by the merge of #189) failed with:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

in `EditParticipantDialogInteraction.test.tsx`, in the test that selects a faction from the Chakra/Ark UI Select dropdown. The test asserted `onParticipantChange` was called immediately after clicking an option, but Ark UI's `onValueChange` propagates asynchronously — under CI's timing this occasionally raced ahead of the assertion.

- Wrapped the faction-select assertion in `waitFor` so it waits for the async `onValueChange` callback instead of asserting synchronously right after the click.
- While verifying the fix, awaiting the select's full settle exposed a related pre-existing race in the very next test (Escape key closes the dialog): pressing `Escape` before the dialog had fully rendered/settled sometimes missed the keydown. Added `await screen.findByRole("dialog")` before the keypress to fix that too.

Verified by running the full file and the whole `client-app` test suite (987 tests) repeatedly — all green, no flakes.

## Test plan

- [x] `npm run test --workspace=client-app` — 118 files / 987 tests passing
- [x] Ran `EditParticipantDialogInteraction.test.tsx` 5x in normal execution order — consistently green
- [x] `npx eslint` on changed file — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01N3uoNJr6Pswgy4Qhvt6NHE)_