### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+Closes #
+
+## Scope
+
+- [ ] client-app
+- [ ] server-app
+- [ ] cron
+- [ ] docker / infra (caddy)
+- [ ] docs
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] Client tests pass locally
+- [ ] Server tests pass locally
+- [ ] Cron job tests pass locally (if touched)
+- [ ] CI passes (tests, coverage, Codacy)
+
+## Security
+
+- [ ] Auth boundary changes reviewed/tested (if applicable)
+- [ ] No new findings expected from ZAP scan for this change
+
+## Checklist
+
+- [ ] No secrets, tokens, or credentials committed
+- [ ] Docs updated if user-facing behavior or setup changed


### PR DESCRIPTION
Adds `.github/pull_request_template.md` covering client/server/cron scope plus auth-boundary and ZAP-scan checkboxes so PRs start with a consistent structure.