### PR TITLE
test: close server-app coverage gaps (auth, csrf, tournament-service, user model, email service)

### DIFF
--- a/server-app/src/infrastructure/socket/socket-service.js
+++ b/server-app/src/infrastructure/socket/socket-service.js
@@ -1,7 +1,6 @@
 import { createAdapter as createMongoAdapter } from "@socket.io/mongo-adapter";
 import { createAdapter as createRedisAdapter } from "@socket.io/redis-adapter";
 import mongoose from "mongoose";
-/* c8 ignore next 7 -- ESM static imports below are replaced by mock.module() in tests; v8 marks multi-line import declarations as uncovered when the real module is never loaded */
 import { Server } from "socket.io";
 
 import {

--- a/server-app/src/interfaces/http/controllers/authentication-controller.js
+++ b/server-app/src/interfaces/http/controllers/authentication-controller.js
@@ -11,7 +11,9 @@ const authorizationCodes = new Map();
 
 // Cleanup interval for expired authorization codes (runs every 15 minutes)
 const CODE_EXPIRATION_TIME = 5 * 60 * 1000; // 5 minutes
-/* c8 ignore next 11 -- background cleanup timer fires every 15 min; exercising it requires timer mocking at module-load time which is incompatible with the existing test-file import order */
+// Background cleanup timer fires every 15 min; exercising it requires timer mocking
+// at module-load time, which is incompatible with the existing test-file import order.
+/* node:coverage disable */
 setInterval(
   () => {
     const now = Date.now();
@@ -26,6 +28,7 @@ setInterval(
   },
   15 * 60 * 1000,
 ).unref();
+/* node:coverage enable */
 
 /** @type {import('express').RequestHandler} */
 export const login = async (req, res) => {
@@ -347,15 +350,17 @@ function generateCodeChallenge(codeVerifier) {
  * @returns {boolean} - True if strings are equal
  */
 function timingSafeEqual(a, b) {
-  /* c8 ignore next 3 -- generateCodeChallenge always returns a string; non-string input is unreachable */
+  // generateCodeChallenge always returns a same-length string; non-string input
+  // and length mismatches are unreachable in practice.
+  /* node:coverage disable */
   if (typeof a !== "string" || typeof b !== "string") {
     return false;
   }
 
-  /* c8 ignore next 3 -- S256 base64url challenges are always the same fixed length; length mismatch is unreachable */
   if (a.length !== b.length) {
     return false;
   }
+  /* node:coverage enable */
 
   // For node.js environment, we can use the built-in crypto.timingSafeEqual
   // but for browsers or if that's not available, implement a more basic version
@@ -363,14 +368,14 @@ function timingSafeEqual(a, b) {
     const bufA = Buffer.from(a, "utf8");
     const bufB = Buffer.from(b, "utf8");
     return crypto.timingSafeEqual(bufA, bufB);
-    /* c8 ignore start -- ascii-only base64url strings cannot cause crypto.timingSafeEqual to throw; this fallback is unreachable in practice */
-    // eslint-disable-next-line no-unused-vars
-  } catch (err) {
+    // ascii-only base64url strings cannot cause crypto.timingSafeEqual to throw;
+    // this fallback is unreachable in practice.
+    /* node:coverage ignore next 7 */
+  } catch {
     let result = 0;
     for (let i = 0; i < a.length; i++) {
       result |= a.charCodeAt(i) ^ b.charCodeAt(i);
     }
     return result === 0;
   }
-  /* c8 ignore stop */
 }

--- a/server-app/src/interfaces/http/middleware/csrf-middleware.js
+++ b/server-app/src/interfaces/http/middleware/csrf-middleware.js
@@ -2,11 +2,13 @@ import { doubleCsrf } from "csrf-csrf";
 
 import logger from "../../../infrastructure/utils/logger.js";
 
-/* c8 ignore next 4 */
+// process.exit() cannot be exercised in-process without killing the test runner.
+/* node:coverage disable */
 if (process.env.NODE_ENV === "production" && !process.env.CSRF_SECRET) {
   logger.error("CSRF_SECRET is not set in production environment");
   process.exit(1);
 }
+/* node:coverage enable */
 
 const CSRF_SECRET =
   process.env.CSRF_SECRET ||

--- a/server-app/src/tests/services/email-service-with-key.test.js
+++ b/server-app/src/tests/services/email-service-with-key.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it, mock } from "node:test";
+
+// Mock env to simulate a configured RESEND_API_KEY before importing EmailService
+mock.module("../../infrastructure/config/env.js", {
+  namedExports: { resendApiKey: "re_test_key" },
+});
+
+const resendConstructorCalls = [];
+
+// Mock the resend package so the module can be imported without the real package
+mock.module("resend", {
+  namedExports: {
+    Resend: class MockResend {
+      constructor(key) {
+        this.key = key;
+        resendConstructorCalls.push(key);
+      }
+    },
+  },
+});
+
+const emailServiceModule =
+  await import("../../infrastructure/services/email-service.js");
+const EmailService = emailServiceModule.default;
+
+describe("EmailService resendClient getter — configured API key", () => {
+  it("lazily instantiates a Resend client using the configured key", () => {
+    const svc = new EmailService();
+    const client = svc.resendClient;
+    assert.equal(client.key, "re_test_key");
+  });
+
+  it("caches the client instance across repeated accesses", () => {
+    const svc = new EmailService();
+    const before = resendConstructorCalls.length;
+
+    const first = svc.resendClient;
+    const second = svc.resendClient;
+
+    assert.equal(resendConstructorCalls.length, before + 1);
+    assert.strictEqual(first, second);
+  });
+});

--- a/server-app/src/tests/services/tournament-service.test.js
+++ b/server-app/src/tests/services/tournament-service.test.js
@@ -855,4 +855,74 @@ describe("doubleElimAdvance bracket reset", () => {
     }
     assert.ok(done, "tournament should reach completed state");
   });
+
+  it("returns 'Grand final not yet completed' when the GF match is still pending", () => {
+    const tid = "t_gf_pending";
+    const allMatches = [
+      {
+        round: 1,
+        matchNumber: 1,
+        bracketSide: "grand_final",
+        status: "pending",
+        player1: { participantId: "p1", name: "Alice" },
+        player2: { participantId: "p2", name: "Bob" },
+        winnerId: null,
+      },
+    ];
+
+    const result = doubleElimAdvance(tid, allMatches);
+
+    assert.deepStrictEqual(result, {
+      completed: false,
+      docs: [],
+      message: "Grand final not yet completed",
+    });
+  });
+
+  it("returns 'Not all current round matches are complete' while the WB round is in progress and no GF exists", () => {
+    const tid = "t_wb_in_progress";
+    const allMatches = [
+      {
+        round: 1,
+        matchNumber: 1,
+        bracketSide: "winners",
+        status: "completed",
+        player1: { participantId: "p1", name: "Alice" },
+        player2: { participantId: "p2", name: "Bob" },
+        winnerId: "p1",
+      },
+      {
+        round: 1,
+        matchNumber: 2,
+        bracketSide: "winners",
+        status: "pending",
+        player1: { participantId: "p3", name: "Carol" },
+        player2: { participantId: "p4", name: "Dave" },
+        winnerId: null,
+      },
+    ];
+
+    const result = doubleElimAdvance(tid, allMatches);
+
+    assert.deepStrictEqual(result, {
+      completed: false,
+      docs: [],
+      message: "Not all current round matches are complete",
+    });
+  });
+});
+
+describe("swissStart bye handling", () => {
+  it("creates a completed bye match for the odd participant out", () => {
+    const tid = "t_swiss_odd";
+    const matches = swissStart(tid, makeParticipants(3));
+
+    assert.strictEqual(matches.length, 2);
+    const bye = matches.find((m) => m.player2.name === "BYE");
+    assert.ok(bye, "expected a bye match among the round 1 pairings");
+    assert.strictEqual(bye.status, "completed");
+    assert.strictEqual(bye.winnerId, bye.player1.participantId);
+    assert.strictEqual(bye.loserId, null);
+    assert.strictEqual(bye.player2.participantId, null);
+  });
 });

--- a/server-app/src/tests/user-model.test.js
+++ b/server-app/src/tests/user-model.test.js
@@ -13,6 +13,8 @@ mock.module("bcrypt", {
   defaultExport: { compare: mockCompare },
 });
 
+const createdSchemas = [];
+
 mock.module("mongoose", {
   defaultExport: {
     Schema: class {
@@ -20,11 +22,15 @@ mock.module("mongoose", {
       index() {}
       methods = {};
     },
-    model: mock.fn(() => ({})),
+    model: mock.fn((name, schema) => {
+      createdSchemas.push(schema);
+      return {};
+    }),
   },
 });
 
 const UserModule = await import("../domain/models/user.js");
+const [userSchema] = createdSchemas;
 
 // The User model has a validatePassword method on instances.
 // Since we mock mongoose, we need to access the method via the Schema prototype.
@@ -54,5 +60,27 @@ describe("user model – validatePassword", () => {
   it("User model is exported", () => {
     // Verify the module exports a User model (even if mocked)
     assert.ok(UserModule.default !== undefined);
+  });
+
+  it("instance method delegates to bcrypt.compare with the stored hash", async () => {
+    mockCompare.mock.mockImplementation(async () => true);
+    const instance = { password: "stored-hash" };
+    const result = await userSchema.methods.validatePassword.call(
+      instance,
+      "correct",
+    );
+    assert.strictEqual(result, true);
+    const lastCall = mockCompare.mock.calls.at(-1);
+    assert.deepStrictEqual(lastCall.arguments, ["correct", "stored-hash"]);
+  });
+
+  it("instance method returns false when bcrypt.compare rejects the password", async () => {
+    mockCompare.mock.mockImplementation(async () => false);
+    const instance = { password: "stored-hash" };
+    const result = await userSchema.methods.validatePassword.call(
+      instance,
+      "wrong",
+    );
+    assert.strictEqual(result, false);
   });
 });


### PR DESCRIPTION
## Summary

Part of an incremental effort to reach 100% unit test coverage. This PR closes the largest server-app coverage gaps (batch of 5 files); client-app and the remaining server-app gaps are left for follow-up PRs.

Server-app coverage (line/branch/func): **99.61% / 98.29% / 95.43% → 99.95% / 98.65% / 95.58%**

## Related issue

Closes #

## Scope

- [ ] client-app
- [x] server-app
- [ ] cron
- [ ] docker / infra (caddy)
- [ ] docs

## Changes

- `authentication-controller.js`: 94.95/94.83/87.50 → **100/100/100**. This project's test command uses Node's built-in `--experimental-test-coverage`, not `c8`/`istanbul` — the existing `/* c8 ignore ... */` comments were silently no-ops. Replaced them with the correct `node:coverage disable`/`enable` and `node:coverage ignore next N` directives around the background cleanup timer and the defensive/unreachable branches in `timingSafeEqual`.
- `csrf-middleware.js`: 96.84/92.31/100 → **100/100/100**. Same `c8 ignore` → `node:coverage disable` fix for the production-only `process.exit()` guard (can't be exercised in-process without killing the test runner).
- `socket-service.js`: removed a dead `c8 ignore` comment that Node's coverage tool never respected and that wasn't actually gating any currently-reported uncovered line.
- `tournament-service.js`: 96.24/88.89/100 → 100/**92.14**/100. Added tests for `doubleElimAdvance`'s two remaining early-return branches (grand final still pending; winners-bracket round still in progress with no grand final yet) and for `swissStart`'s odd-participant bye-match path.
- `domain/models/user.js`: 95.00/100/**0.00** → **100/100/100**. The existing test only re-invoked `bcrypt.compare` directly and never actually called `userSchema.methods.validatePassword` — hence 0% function coverage despite passing tests. Now captures the schema instance passed to the mocked `mongoose.model()` and invokes the real method.
- `email-service.js`: 96.51/85.71/100 → 100/**92.86**/100. Added a test file covering the `resendClient` getter's lazy-instantiation and caching branches when `RESEND_API_KEY` is configured (previously only the missing-key throw path was covered).

## Testing

- [x] Client tests pass locally (unaffected — no client-app changes)
- [x] Server tests pass locally (567/567 passing: `node --experimental-vm-modules --experimental-test-module-mocks --test`)
- [ ] Cron job tests pass locally (if touched) — N/A
- [ ] CI passes (tests, coverage, Codacy)

## Security

- [ ] Auth boundary changes reviewed/tested (if applicable) — N/A, no auth *behavior* changed, only coverage-directive/test changes
- [ ] No new findings expected from ZAP scan for this change — N/A, no runtime behavior changed

## Checklist

- [x] No secrets, tokens, or credentials committed
- [ ] Docs updated if user-facing behavior or setup changed — N/A, no user-facing changes

## Remaining coverage gaps (follow-up PRs)

Server-app: `auth-state-service.js` (branch/func), `redis-service.js` (func), `stats-service.js` (func), `match-controller.js` / `tournament-controller.js` / `user-controller.js` (func).

Client-app (bigger effort — currently ~95.7%/92.0%/96.0% stmts/branch/func): `MatchesPage.tsx`, `MatchesSection.tsx`, `TournamentViewPage.tsx`, `TournamentDetail.tsx` have the largest remaining gaps.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NyY4Xs6MkWZYGsqvudYoKt)_