### PR TITLE
feat(ui): improve tournament card contrast (ongoing + past)

### DIFF
--- a/client-app/src/features/tournaments/components/TournamentBrowser.tsx
+++ b/client-app/src/features/tournaments/components/TournamentBrowser.tsx
@@ -32,7 +32,7 @@ const statusColorMap: Record<string, string> = {
 const statusAccentMap: Record<string, string> = {
   pending: "status.pending.border",
   active: "info.border",
-  completed: "border.emphasized",
+  completed: "gold.border",
 };
 
 const statusBarMap: Record<string, string> = {
@@ -79,7 +79,7 @@ const TournamentBrowser: React.FC<Props> = ({ statusFilter, emptyMessage }) => {
   const { user, isAuthenticated } = useUserStore();
   const navigate = useNavigate();
   const cardBg = "bg.panel";
-  const borderColor = "border";
+  const borderColor = "border.subtle";
 
   const fetchTournaments = useCallback(async () => {
     setLoading(true);
@@ -167,6 +167,8 @@ const TournamentBrowser: React.FC<Props> = ({ statusFilter, emptyMessage }) => {
                   borderTopWidth="2px"
                   display="flex"
                   flexDirection="column"
+                  transition="all 0.15s ease"
+                  _hover={{ bg: "bg.elevated", shadow: "md" }}
                 >
                   <Card.Body flex={1}>
                     <VStack alignItems="flex-start" gap={2}>

--- a/client-app/src/shared/ui/theme.ts
+++ b/client-app/src/shared/ui/theme.ts
@@ -332,7 +332,7 @@ const config = defineConfig({
             value: { _light: "#B7AD9B", _dark: "#332D24" },
           },
           elevated: {
-            value: { _light: "#FFFFFF", _dark: "#221D17" },
+            value: { _light: "#FFFFFF", _dark: "#2A241C" },
           },
           panel: {
             value: { _light: "#FFFFFF", _dark: "#221D17" },


### PR DESCRIPTION
## Summary

Tournament cards in the browser (the component that renders **both** the "View Ongoing Tournaments" and "View Past Tournaments" tabs) had poor contrast in dark mode — the card border (`#332D24`) was nearly identical to the card background (`bg.panel` `#221D17`), so card edges effectively vanished and cards blended into the page. Past-tournament cards were flattest because their top accent used a faint neutral (`border.emphasized` `#4F4940`). The cards also had no hover affordance, unlike the Matches list.

This tightens card separation in both light and dark mode, adds a hover lift, and gives completed/past cards a clear heraldic gold accent.

## Related issue

Closes #

## Scope

- [x] client-app
- [ ] server-app
- [ ] cron
- [ ] docker / infra (caddy)
- [ ] docs

## Changes

- **`TournamentBrowser.tsx`** — resting `borderColor` `border` → `border.subtle` (dark `#332D24` → `#473F32`, light `#D5CCBA` → `#BEB39B`) so card edges read clearly.
- **`TournamentBrowser.tsx`** — added `_hover={{ bg: "bg.elevated", shadow: "md" }}` + `transition="all 0.15s ease"` on `Card.Root`, matching the existing pattern in `TournamentList.tsx`.
- **`TournamentBrowser.tsx`** — past-tournament top accent `statusAccentMap.completed`: `border.emphasized` → `gold.border` (dark `#4F4940` → `#5A4715`) for a clear heraldic accent on completed cards. Progress-bar fill left untouched.
- **`theme.ts`** — `bg.elevated` dark `#221D17` → `#2A241C` so the new hover state actually lifts (it previously equalled `bg.panel` and was a no-op). Light value unchanged.

All styling uses existing semantic tokens — no raw hex in component code. Scope is deliberately limited to tournament cards + one supporting token repair; the global `border` token is untouched to avoid affecting the ~15 other `Card.Root` consumers.

## Testing

- [x] Client tests pass locally — all 40 `TournamentBrowser` tests pass; full client suite passes except one pre-existing socket-isolation failure in `MatchesPageHandlers.test.tsx` that also fails on `main` and passes in isolation (unrelated to this change).
- [ ] Server tests pass locally — N/A (no server changes)
- [ ] Cron job tests pass locally (if touched) — N/A
- [ ] CI passes (tests, coverage, Codacy)

> Note: `npm run lint` reports 32 pre-existing `no-explicit-any` errors in **test files** that also fail on `main`; none are in the files touched by this PR.

## Security

- [ ] Auth boundary changes reviewed/tested (if applicable) — N/A
- [x] No new findings expected from ZAP scan for this change — UI-only token/prop swap

## Checklist

- [x] No secrets, tokens, or credentials committed
- [x] Docs updated if user-facing behavior or setup changed — no setup/user-facing doc impact (internal styling tokens only)