### PR TITLE
feat(ui): improve card contrast in tournament detail view

### DIFF
--- a/client-app/src/features/tournaments/components/TournamentViewPage.tsx
+++ b/client-app/src/features/tournaments/components/TournamentViewPage.tsx
@@ -118,7 +118,9 @@ const TournamentViewPage: React.FC<{ id?: string }> = ({ id: propId }) => {
   const [joinSuccess, setJoinSuccess] = useState(false);
 
   const cardBg = "bg.panel";
-  const borderColor = "border";
+  // border.subtle (#BEB39B light / #473F32 dark) is the clearly-visible step;
+  // the default border token washes into bg.panel in both modes.
+  const borderColor = "border.subtle";
   const mutedBg = "bg.subtle";
 
   const fetchTournament = useCallback(
@@ -500,7 +502,7 @@ const TournamentViewPage: React.FC<{ id?: string }> = ({ id: propId }) => {
         gap={6}
       >
         {/* Participants */}
-        <Card.Root bg={cardBg}>
+        <Card.Root bg={cardBg} borderColor={borderColor} shadow="sm">
           <Card.Header>
             <HStack gap={2}>
               <LuUsers />
@@ -551,7 +553,7 @@ const TournamentViewPage: React.FC<{ id?: string }> = ({ id: propId }) => {
         </Card.Root>
 
         {/* Tournament Info */}
-        <Card.Root bg={cardBg}>
+        <Card.Root bg={cardBg} borderColor={borderColor} shadow="sm">
           <Card.Header>
             <HStack gap={2}>
               <LuTrophy />
@@ -624,7 +626,7 @@ const TournamentViewPage: React.FC<{ id?: string }> = ({ id: propId }) => {
 
         {/* Join panel — only shown when pending and user can/could join */}
         {isPending && (
-          <Card.Root bg={cardBg}>
+          <Card.Root bg={cardBg} borderColor={borderColor} shadow="sm">
             <Card.Header>
               <HStack gap={2}>
                 <LuLogIn />
@@ -734,7 +736,12 @@ const TournamentViewPage: React.FC<{ id?: string }> = ({ id: propId }) => {
 
         {/* Matches — active/completed */}
         {(isActive || tournament.status === "completed") && (
-          <Card.Root gridColumn={{ lg: "1 / -1" }} bg={cardBg}>
+          <Card.Root
+            gridColumn={{ lg: "1 / -1" }}
+            bg={cardBg}
+            borderColor={borderColor}
+            shadow="sm"
+          >
             <Card.Header>
               <HStack gap={2}>
                 <LuSwords />


### PR DESCRIPTION
The four cards on the tournament detail page (Participants, Tournament Info, Join, Matches) relied on Chakra's default outline variant: a 1px border token (#D5CCBA light / #332D24 dark) and no shadow. In light mode the white cards blended into the beige page; in dark mode the panel sat only ~5% above the canvas with a near-identical edge.

This mirrors the fix already applied to TournamentBrowser in 176122c:
- borderColor const: border -> border.subtle (#BEB39B light / #473F32 dark), the clearly-visible step. Also repairs the inner participant rows and pending match boxes, which reuse the const.
- all four Card.Root panels get borderColor + shadow="sm" for a resting lift.

No theme.ts change needed. Scoped to the detail view; other Card consumers are unaffected.

## Summary

<!-- What does this PR change, and why? -->

## Related issue

Closes #

## Scope

- [ ] client-app
- [ ] server-app
- [ ] cron
- [ ] docker / infra (caddy)
- [ ] docs

## Changes

-

## Testing

- [ ] Client tests pass locally
- [ ] Server tests pass locally
- [ ] Cron job tests pass locally (if touched)
- [ ] CI passes (tests, coverage, Codacy)

## Security

- [ ] Auth boundary changes reviewed/tested (if applicable)
- [ ] No new findings expected from ZAP scan for this change

## Checklist

- [ ] No secrets, tokens, or credentials committed
- [ ] Docs updated if user-facing behavior or setup changed
