### PR TITLE
chore: declare repo-level Claude Code plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true,
     "github@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "context7@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,9 @@ Thumbs.db
 *.sublime-workspace
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/settings.json
+.claude/settings.local.json
 
 # Optional npm cache & test coverage
 .npm/


### PR DESCRIPTION
## Summary
- Adds `typescript-lsp`, `github`, `security-guidance`, `frontend-design`, `claude-md-management`, and `context7` to `.claude/settings.json` `enabledPlugins`
- Un-ignores `.claude/settings.json` in `.gitignore` (keeps `.claude/settings.local.json` ignored)
- So anyone cloning the repo with Claude Code picks up the relevant skills/LSPs automatically, without a manual install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)